### PR TITLE
Add Peptidoform Scoring Control

### DIFF
--- a/modules/local/diann/assemble_empirical_library/main.nf
+++ b/modules/local/diann/assemble_empirical_library/main.nf
@@ -48,6 +48,7 @@ process ASSEMBLE_EMPIRICAL_LIBRARY {
         mass_acc = '--individual-mass-acc'
     }
     scan_window = params.scan_window_automatic ? '--individual-windows' : "--window $params.scan_window"
+    diann_no_peptidoforms = params.diann_no_peptidoforms ? "--no-peptidoforms" : ""
 
     """
     # Precursor Tolerance value was: ${meta['precursormasstolerance']}
@@ -71,6 +72,7 @@ process ASSEMBLE_EMPIRICAL_LIBRARY {
             ${mass_acc} \\
             ${scan_window} \\
             --gen-spec-lib \\
+            ${diann_no_peptidoforms} \\
             \${mod_flags} \\
             $args
 

--- a/modules/local/diann/final_quantification/main.nf
+++ b/modules/local/diann/final_quantification/main.nf
@@ -65,6 +65,7 @@ process FINAL_QUANTIFICATION {
     quantums_train_runs = params.quantums_train_runs ? "--quant-train-runs $params.quantums_train_runs": ""
     quantums_sel_runs = params.quantums_sel_runs ? "--quant-sel-runs $params.quantums_sel_runs": ""
     quantums_params = params.quantums_params ? "--quant-params $params.quantums_params": ""
+    diann_no_peptidoforms = params.diann_no_peptidoforms ? "--no-peptidoforms" : ""
 
     """
     # Notes: if .quant files are passed, mzml/.d files are not accessed, so the name needs to be passed but files
@@ -93,6 +94,7 @@ process FINAL_QUANTIFICATION {
             ${quantums_train_runs} \\
             ${quantums_sel_runs} \\
             ${quantums_params} \\
+            ${diann_no_peptidoforms} \\
             \${mod_flags} \\
             $args
 

--- a/modules/local/diann/individual_analysis/main.nf
+++ b/modules/local/diann/individual_analysis/main.nf
@@ -57,6 +57,8 @@ process INDIVIDUAL_ANALYSIS {
         mass_acc_ms1 = "\$(cat ${diann_log} | grep \"Averaged recommended settings\" | cut -d ' ' -f 15 | tr -cd \"[0-9]\")"
     }
 
+    diann_no_peptidoforms = params.diann_no_peptidoforms ? "--no-peptidoforms" : ""
+
     """
     # Extract --var-mod and --fixed-mod flags from diann_config.cfg (DIA-NN best practice)
     mod_flags=\$(cat ${diann_config} | grep -oP '(--var-mod\\s+\\S+|--fixed-mod\\s+\\S+)' | tr '\\n' ' ')
@@ -74,6 +76,7 @@ process INDIVIDUAL_ANALYSIS {
             --no-main-report \\
             --relaxed-prot-inf \\
             --pg-level $params.pg_level \\
+            ${diann_no_peptidoforms} \\
             \${mod_flags} \\
             $args
 

--- a/modules/local/diann/insilico_library_generation/main.nf
+++ b/modules/local/diann/insilico_library_generation/main.nf
@@ -43,6 +43,7 @@ process INSILICO_LIBRARY_GENERATION {
     min_fr_mz = params.min_fr_mz ? "--min-fr-mz $params.min_fr_mz":""
     max_fr_mz = params.max_fr_mz ? "--max-fr-mz $params.max_fr_mz":""
     met_excision = params.met_excision ? "--met-excision" : ""
+    diann_no_peptidoforms = params.diann_no_peptidoforms ? "--no-peptidoforms" : ""
 
     """
     diann `cat diann_config.cfg` \\
@@ -62,6 +63,7 @@ process INSILICO_LIBRARY_GENERATION {
             --predictor \\
             --verbose $params.diann_debug \\
             --gen-spec-lib \\
+            ${diann_no_peptidoforms} \\
             ${met_excision} \\
             ${args}
 

--- a/modules/local/diann/preliminary_analysis/main.nf
+++ b/modules/local/diann/preliminary_analysis/main.nf
@@ -38,6 +38,7 @@ process PRELIMINARY_ANALYSIS {
     // Performance flags for preliminary analysis calibration step
     quick_mass_acc = params.quick_mass_acc ? "--quick-mass-acc" : ""
     performance_flags = params.performance_mode ? "--min-corr 2 --corr-diff 1 --time-corr-only" : ""
+    diann_no_peptidoforms = params.diann_no_peptidoforms ? "--no-peptidoforms" : ""
 
     // I am using here the ["key"] syntax, since the preprocessed meta makes
     // was evaluating to null when using the dot notation.
@@ -74,6 +75,7 @@ process PRELIMINARY_ANALYSIS {
             ${mass_acc} \\
             ${quick_mass_acc} \\
             ${performance_flags} \\
+            ${diann_no_peptidoforms} \\
             \${mod_flags} \\
             $args
 

--- a/nextflow.config
+++ b/nextflow.config
@@ -88,6 +88,7 @@ params {
     quantums_train_runs     = null
     quantums_sel_runs       = null
     quantums_params         = null
+    diann_no_peptidoforms   = false // add '--no-peptidoforms'
 
     // pmultiqc options
     enable_pmultiqc          = true

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -409,6 +409,12 @@
                     "help_text": "Sets the DIA-NN parameter --quant-params. Provide previously obtained QuantUMS parameters to use instead of training new ones.",
                     "hidden": false
                 },
+                "diann_no_peptidoforms": {
+                    "type": "boolean",
+                    "description": "Set no-peptidoforms mode: disables automatic peptidoform scoring when variable modifications are declared (DIA-NN: not recommended)",
+                    "fa_icon": "far fa-check-square",
+                    "default": false
+                },
                 "skip_preliminary_analysis": {
                     "type": "boolean",
                     "description": "Skip the preliminary analysis step, thus use the passed spectral library as-is instead of generating a local concensus library.",


### PR DESCRIPTION
### Testing completed: (Phase 2) 2d. Phospho: Peptidoform Scoring Control
DIA-NN: (--no-peptidoforms) disables automatic activation of peptidoform scoring when variable modifications are declared, not recommended.

After testing, the DIA-NN log only stops showing "`WARNING: peptidoform scoring enabled because variable modifications have been declared; to disable, use --no-peptidoforms : 1`" when `diann_no_peptidoforms` is applied in all subworkflows.
| Subworkflows |
| ----- |
| INSILICO_LIBRARY_GENERATION |
| PRELIMINARY_ANALYSIS |
| ASSEMBLE_EMPIRICAL_LIBRARY |
| INDIVIDUAL_ANALYSIS |
| FINAL_QUANTIFICATION |


#### New params:
| Parameter | Type | Default |
| ----- | ----- | ----- |
| --diann_no_peptidoforms | boolean | false |

#### Tested (Run PXD026600 with --diann_no_peptidoforms true):
| Version |	Test Passed |
| ---- | ------- |
| 2.0 | ✅ |
| 2.1.0 | ✅ |
| 2.2.0 | ✅ |
| 2.3.2 | ✅ |