### PR TITLE
Add Bruker/timsTOF auto-calibration warning

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -29,6 +29,26 @@ The pipeline supports the following mass spectrometry data file formats:
 
 Compressed variants are supported for `.raw`, `.mzML`, and `.d` formats: `.gz`, `.tar`, `.tar.gz`, `.zip`.
 
+### Bruker/timsTOF Data
+
+For Bruker timsTOF datasets, DIA-NN recommends manually fixing MS1 and MS2 mass accuracy to 10-15 ppm rather than using automatic calibration:
+
+```bash
+nextflow run bigbio/quantmsdiann \
+  --input sdrf.tsv \
+  --database proteins.fasta \
+  --mass_acc_automatic false \
+  --mass_acc_ms1 10 \
+  --mass_acc_ms2 10 \
+  --diann_tims_sum \
+  -profile docker
+```
+
+For Synchro-PASEF data, enable `--diann_tims_sum` (which adds `--quant-tims-sum` to DIA-NN).
+
+> [!NOTE]
+> The pipeline will emit a warning during PRELIMINARY_ANALYSIS if it detects `.d` files with automatic mass accuracy calibration enabled.
+
 ### Pipeline settings via params file
 
 Pipeline settings can be provided in a `yaml` or `json` file via `-params-file <file>`:

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -31,23 +31,28 @@ Compressed variants are supported for `.raw`, `.mzML`, and `.d` formats: `.gz`, 
 
 ### Bruker/timsTOF Data
 
-For Bruker timsTOF datasets, DIA-NN recommends manually fixing MS1 and MS2 mass accuracy to 10-15 ppm rather than using automatic calibration:
+For Bruker timsTOF datasets, DIA-NN recommends manually fixing MS1 and MS2 mass accuracy (typically 10-15 ppm) rather than using automatic calibration. There are two ways to set this:
+
+**Option 1 — SDRF columns (per-file control, recommended):**
+
+Set `PrecursorMassTolerance`, `PrecursorMassToleranceUnit`, `FragmentMassTolerance`, and `FragmentMassToleranceUnit` columns in your SDRF file. The pipeline reads these per-file and passes them to DIA-NN when `--mass_acc_automatic false` is set. This allows different tolerances for different files in the same experiment.
+
+**Option 2 — Pipeline parameters (global override):**
 
 ```bash
 nextflow run bigbio/quantmsdiann \
   --input sdrf.tsv \
   --database proteins.fasta \
   --mass_acc_automatic false \
-  --mass_acc_ms1 10 \
-  --mass_acc_ms2 10 \
-  --diann_tims_sum \
+  --mass_acc_ms1 <value> \
+  --mass_acc_ms2 <value> \
   -profile docker
 ```
 
 For Synchro-PASEF data, enable `--diann_tims_sum` (which adds `--quant-tims-sum` to DIA-NN).
 
 > [!NOTE]
-> The pipeline will emit a warning during PRELIMINARY_ANALYSIS if it detects `.d` files with automatic mass accuracy calibration enabled.
+> The pipeline will emit a warning during PRELIMINARY_ANALYSIS if it detects `.d` files with automatic mass accuracy calibration enabled, recommending to set tolerances via SDRF or pipeline parameters.
 
 ### Pipeline settings via params file
 

--- a/modules/local/diann/preliminary_analysis/main.nf
+++ b/modules/local/diann/preliminary_analysis/main.nf
@@ -54,6 +54,13 @@ process PRELIMINARY_ANALYSIS {
         mass_acc = ""
     }
 
+    // Warn about auto-calibration with Bruker/timsTOF data
+    if (params.mass_acc_automatic && ms_file.name.toString().toLowerCase().endsWith('.d')) {
+        log.warn "Bruker/timsTOF .d file detected (${ms_file.name}) with automatic mass accuracy calibration enabled. " +
+            "DIA-NN recommends manually fixing MS1 and MS2 mass accuracy to 10-15 ppm for timsTOF datasets. " +
+            "Consider using: --mass_acc_automatic false --mass_acc_ms1 10 --mass_acc_ms2 10"
+    }
+
     // Notes: Use double quotes for params, so that it is escaped in the shell.
     scan_window = params.scan_window_automatic ? '' : "--window $params.scan_window"
     diann_tims_sum = params.diann_tims_sum ? "--quant-tims-sum" : ""

--- a/modules/local/diann/preliminary_analysis/main.nf
+++ b/modules/local/diann/preliminary_analysis/main.nf
@@ -56,9 +56,10 @@ process PRELIMINARY_ANALYSIS {
 
     // Warn about auto-calibration with Bruker/timsTOF data
     if (params.mass_acc_automatic && ms_file.name.toString().toLowerCase().endsWith('.d')) {
-        log.warn "Bruker/timsTOF .d file detected (${ms_file.name}) with automatic mass accuracy calibration enabled. " +
-            "DIA-NN recommends manually fixing MS1 and MS2 mass accuracy to 10-15 ppm for timsTOF datasets. " +
-            "Consider using: --mass_acc_automatic false --mass_acc_ms1 10 --mass_acc_ms2 10"
+        log.warn "Bruker/timsTOF .d file detected (${ms_file.name}) with automatic mass accuracy calibration. " +
+            "DIA-NN recommends manually fixing MS1 and MS2 mass accuracy for timsTOF datasets (typically 10-15 ppm). " +
+            "Set tolerances via SDRF columns (PrecursorMassTolerance, FragmentMassTolerance) for per-file control, " +
+            "or use --mass_acc_automatic false with --mass_acc_ms1 and --mass_acc_ms2 pipeline parameters for a global override."
     }
 
     // Notes: Use double quotes for params, so that it is escaped in the shell.


### PR DESCRIPTION
## Summary
- Add a `log.warn` in `PRELIMINARY_ANALYSIS` when `.d` files are processed with `mass_acc_automatic=true`, advising users to manually set mass accuracy to 10-15 ppm for timsTOF data
- Add a "Bruker/timsTOF Data" section to `docs/usage.md` with recommended parameters and example command

## Test plan
- [ ] Run `nextflow run . -profile test_dia_dotd,docker --outdir results` and verify warning appears in log output
- [ ] Run `nextflow run . -profile test_dia,docker --outdir results` (non-.d files) and verify no warning appears
- [ ] Review docs rendering on GitHub

Closes #26

🤖 Generated with [Claude Code](https://claude.com/claude-code)