### PR TITLE
feat: rename FDR params and expose matrix-level q-value controls

### DIFF
--- a/docs/parameters.md
+++ b/docs/parameters.md
@@ -148,7 +148,9 @@ This document lists every pipeline parameter organised by category. Default valu
 | `--enable_pmultiqc`          | boolean | `true`  | Generate the pmultiqc QC report.                                                     |
 | `--pmultiqc_idxml_skip`      | boolean | `true`  | Skip idXML files (do not generate search engine score plots) in the pmultiqc report. |
 | `--contaminant_string`       | string  | `CONT`  | Contaminant affix string for pmultiqc. Maps to `--contaminant_affix` in pmultiqc.    |
-| `--protein_level_fdr_cutoff` | number  | `0.01`  | Experiment-wide protein (group)-level FDR cutoff.                                    |
+| `--precursor_qvalue`         | number  | `0.01`  | Precursor-level q-value threshold for the DIA-NN main report. Maps to `--qvalue`.    |
+| `--matrix_qvalue`            | number  | `0.01`  | Q-value threshold for DIA-NN output matrices (pr_matrix, pg_matrix). Maps to `--matrix-qvalue`. |
+| `--matrix_spec_q`            | number  | `0.05`  | Run-specific protein q-value for protein/gene matrices. Maps to `--matrix-spec-q`.   |
 
 ## 15. MultiQC & Reporting
 

--- a/docs/parameters.md
+++ b/docs/parameters.md
@@ -143,14 +143,14 @@ This document lists every pipeline parameter organised by category. Default valu
 
 ## 14. Quality Control
 
-| Parameter                    | Type    | Default | Description                                                                          |
-| ---------------------------- | ------- | ------- | ------------------------------------------------------------------------------------ |
-| `--enable_pmultiqc`          | boolean | `true`  | Generate the pmultiqc QC report.                                                     |
-| `--pmultiqc_idxml_skip`      | boolean | `true`  | Skip idXML files (do not generate search engine score plots) in the pmultiqc report. |
-| `--contaminant_string`       | string  | `CONT`  | Contaminant affix string for pmultiqc. Maps to `--contaminant_affix` in pmultiqc.    |
-| `--precursor_qvalue`         | number  | `0.01`  | Precursor-level q-value threshold for the DIA-NN main report. Maps to `--qvalue`.    |
-| `--matrix_qvalue`            | number  | `0.01`  | Q-value threshold for DIA-NN output matrices (pr_matrix, pg_matrix). Maps to `--matrix-qvalue`. |
-| `--matrix_spec_q`            | number  | `0.05`  | Run-specific protein q-value for protein/gene matrices. Maps to `--matrix-spec-q`.   |
+| Parameter               | Type    | Default | Description                                                                                     |
+| ----------------------- | ------- | ------- | ----------------------------------------------------------------------------------------------- |
+| `--enable_pmultiqc`     | boolean | `true`  | Generate the pmultiqc QC report.                                                                |
+| `--pmultiqc_idxml_skip` | boolean | `true`  | Skip idXML files (do not generate search engine score plots) in the pmultiqc report.            |
+| `--contaminant_string`  | string  | `CONT`  | Contaminant affix string for pmultiqc. Maps to `--contaminant_affix` in pmultiqc.               |
+| `--precursor_qvalue`    | number  | `0.01`  | Precursor-level q-value threshold for the DIA-NN main report. Maps to `--qvalue`.               |
+| `--matrix_qvalue`       | number  | `0.01`  | Q-value threshold for DIA-NN output matrices (pr_matrix, pg_matrix). Maps to `--matrix-qvalue`. |
+| `--matrix_spec_q`       | number  | `0.05`  | Run-specific protein q-value for protein/gene matrices. Maps to `--matrix-spec-q`.              |
 
 ## 15. MultiQC & Reporting
 

--- a/modules/local/diann/diann_msstats/main.nf
+++ b/modules/local/diann/diann_msstats/main.nf
@@ -22,7 +22,7 @@ process DIANN_MSSTATS {
     quantmsutilsc diann2msstats \\
         --report ${report} \\
         --exp_design ${exp_design} \\
-        --qvalue_threshold $params.protein_level_fdr_cutoff \\
+        --qvalue_threshold $params.precursor_qvalue \\
         $args \\
         2>&1 | tee convert_report.log
 

--- a/modules/local/diann/final_quantification/main.nf
+++ b/modules/local/diann/final_quantification/main.nf
@@ -47,7 +47,7 @@ process FINAL_QUANTIFICATION {
     def blocked = ['--no-main-report', '--gen-spec-lib', '--out-lib', '--no-ifs-removal',
          '--temp', '--threads', '--verbose', '--lib', '--f', '--fasta',
          '--use-quant', '--matrices', '--out', '--relaxed-prot-inf', '--pg-level',
-         '--qvalue', '--window', '--individual-windows',
+         '--qvalue', '--matrix-qvalue', '--matrix-spec-q', '--window', '--individual-windows',
          '--species-genes', '--report-decoys', '--xic', '--no-norm',
          '--monitor-mod', '--var-mod', '--fixed-mod', '--dda', '--export-quant', '--site-ms1-quant',
          '--channels', '--lib-fixed-mod', '--original-mods']
@@ -97,7 +97,9 @@ process FINAL_QUANTIFICATION {
             ${no_norm} \\
             --matrices \\
             --out diann_report.tsv \\
-            --qvalue $params.protein_level_fdr_cutoff \\
+            --qvalue $params.precursor_qvalue \\
+            --matrix-qvalue $params.matrix_qvalue \\
+            --matrix-spec-q $params.matrix_spec_q \\
             ${report_decoys} \\
             ${diann_export_xic} \\
             ${quantums} \\

--- a/nextflow.config
+++ b/nextflow.config
@@ -19,7 +19,9 @@ params {
     use_ols_cache_only         = true // Use only the OLS cache for ontology validation (no network requests)
 
     // Tools flags
-    protein_level_fdr_cutoff = 0.01
+    precursor_qvalue        = 0.01   // --qvalue: precursor-level q-value threshold for main report
+    matrix_qvalue           = 0.01   // --matrix-qvalue: q-value threshold for output matrices
+    matrix_spec_q           = 0.05   // --matrix-spec-q: run-specific protein q-value for protein/gene matrices
 
     // Debug level
     pp_debug                = 0

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -248,22 +248,6 @@
             },
             "fa_icon": "fas fa-star-half-alt"
         },
-        "protein_inference": {
-            "title": "Protein inference",
-            "type": "object",
-            "description": "To group proteins, calculate scores on the protein (group) level and to potentially modify associations from peptides to proteins.",
-            "default": "",
-            "properties": {
-                "protein_level_fdr_cutoff": {
-                    "type": "number",
-                    "description": "The experiment-wide protein (group)-level FDR cutoff. Default: 0.01",
-                    "default": 0.01,
-                    "fa_icon": "fas fa-filter",
-                    "help_text": "This can be protein level if 'strictly_unique_peptides' are used for protein quantification. See [`--protein_quant`](#protein_quant)"
-                }
-            },
-            "fa_icon": "fab fa-hubspot"
-        },
         "DIA-NN": {
             "title": "DIA-NN",
             "type": "object",
@@ -336,6 +320,27 @@
                     "fa_icon": "fas fa-list-ol",
                     "enum": [0, 1, 2],
                     "default": 2
+                },
+                "precursor_qvalue": {
+                    "type": "number",
+                    "description": "Precursor-level q-value filtering threshold for the DIA-NN main report. Maps to --qvalue.",
+                    "default": 0.01,
+                    "fa_icon": "fas fa-filter",
+                    "help_text": "Controls how strictly precursor identifications are filtered in the DIA-NN main report. For proteogenomics with variant databases, the standard 0.01 (1%) is recommended."
+                },
+                "matrix_qvalue": {
+                    "type": "number",
+                    "description": "Q-value threshold for DIA-NN output matrices (pr_matrix, pg_matrix, etc.). Maps to --matrix-qvalue.",
+                    "default": 0.01,
+                    "fa_icon": "fas fa-filter",
+                    "help_text": "Controls the global q-value filtering applied when generating the quantification matrices. Default matches DIA-NN's built-in default of 1%."
+                },
+                "matrix_spec_q": {
+                    "type": "number",
+                    "description": "Run-specific protein q-value filter for protein/gene matrices. Maps to --matrix-spec-q.",
+                    "default": 0.05,
+                    "fa_icon": "fas fa-filter",
+                    "help_text": "An additional run-specific protein-level FDR filter applied to the protein and gene matrices. Default matches DIA-NN's built-in default of 5%. For proteogenomics/variant detection, consider setting to 1.0 to retain variant proteins that lack sufficient unique peptides for protein-level confidence."
                 },
                 "species_genes": {
                     "type": "boolean",
@@ -721,9 +726,6 @@
         },
         {
             "$ref": "#/$defs/psm_re_scoring_general"
-        },
-        {
-            "$ref": "#/$defs/protein_inference"
         },
         {
             "$ref": "#/$defs/DIA-NN"


### PR DESCRIPTION
## Summary
- Rename `protein_level_fdr_cutoff` → `precursor_qvalue` to accurately reflect DIA-NN's `--qvalue` (precursor-level, not protein-level)
- Expose `matrix_qvalue` (default 0.01, maps to `--matrix-qvalue`) and `matrix_spec_q` (default 0.05, maps to `--matrix-spec-q`)
- Remove misleading "Protein inference" schema section; new params live under "DIA-NN"
- Add `--matrix-qvalue` and `--matrix-spec-q` to blocked flags in FINAL_QUANTIFICATION

## Proteogenomics use case
Users can now set `--matrix_spec_q 1.0` to retain variant proteins (e.g., COSMIC) that always have Protein.Q.Value = 1.0 due to insufficient unique peptides, without affecting precursor-level filtering.

Closes #42

## Test plan
- [ ] Run with default params — verify DIA-NN receives `--qvalue 0.01 --matrix-qvalue 0.01 --matrix-spec-q 0.05`
- [ ] Run with `--matrix_spec_q 1.0` — verify variant proteins are retained in pg_matrix
- [ ] Verify `--diann_extra_args '--matrix-qvalue 0.05'` is stripped with a warning

🤖 Generated with [Claude Code](https://claude.com/claude-code)