### PR TITLE
chore: bump version to 2.0.0 (Rome) and update CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,62 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.0.0] bigbio/quantmsdiann — Rome - 2026-04-12
+
+### `Added`
+
+- DDA analysis mode support (requires DIA-NN >= 2.3.2), auto-detected from SDRF or set via `--dda`
+- DIA-NN 2.3.2 version profile (`-profile diann_v2_3_2`) with InfinDIA and DDA support
+- Scoring mode parameter (`--scoring_mode`): `generic` (default), `proteoforms` (proteogenomics/variant detection, >= 2.0), `peptidoforms` (PTM analysis)
+- FDR controls: `--precursor_qvalue`, `--matrix_qvalue`, `--matrix_spec_q` replacing the misleadingly named `protein_level_fdr_cutoff`
+- Channel normalization flags: `--channel_run_norm`, `--channel_spec_norm` for multiplexing workflows (plexDIA/SILAC)
+- InfinDIA support: `--enable_infin_dia`, `--pre_select` for ultra-large search spaces (DIA-NN >= 2.3.0)
+- Fragment-level export: `--export_quant` for parquet fragment data (DIA-NN >= 2.0)
+- MS1 PTM quantification: `--site_ms1_quant` (DIA-NN >= 2.0)
+- Skip preliminary analysis: `--skip_preliminary_analysis` to use a provided spectral library directly
+- Centralized blocked-flags registry (`lib/BlockedFlags.groovy`) replacing duplicated per-module logic
+- Version guards for all DIA-NN version-dependent features with clear error messages
+- `VersionUtils.groovy` for semantic version comparison (replaces fragile string comparisons)
+- Log capture via `tee` fallback in all DIA-NN modules for robust log handling across versions
+- CI: `test_dda` and `test_dia_skip_preanalysis` test profiles
+
+### `Changed`
+
+- Removed `diann_` prefix from all user-facing parameters (e.g., `--diann_report_decoys` → `--report_decoys`, `--diann_normalize` → `--normalize`)
+- Removed `diann_no_peptidoforms` parameter (superseded by `--scoring_mode`)
+- Separated FINAL_QUANTIFICATION report output into parquet and TSV channels (DIA-NN >= 1.9 produces parquet)
+- Matrix/stats outputs in FINAL_QUANTIFICATION now `optional: true` for DIA-NN 2.x compatibility
+- Decoupled container engine from DIA-NN version configs (engine selected via `-profile`, not version config)
+- Removed hardcoded DIA-NN container from `pride_codon_slurm.config`
+- Updated Zenodo DOI to 10.5281/zenodo.19437128
+
+### `Removed`
+
+- `tdf2mzml` module and all references (Bruker .d files handled natively by DIA-NN >= 2.0)
+- `protein_level_fdr_cutoff` parameter (replaced by `precursor_qvalue`)
+- `diann_no_peptidoforms` parameter (replaced by `scoring_mode`)
+
+### `Fixed`
+
+- DIA-NN log file handling for versions >= 2.x that don't produce `*.log.txt` files
+- `DIANN_MSSTATS` receiving both parquet and TSV when both exist (now only one format reaches downstream)
+- Missing blocked flags: `--no-prot-inf` in ASSEMBLE/INDIVIDUAL/FINAL, `--channel-run-norm`/`--channel-spec-norm` in FINAL, `--var-mod`/`--fixed-mod`/`--channels` in INSILICO
+- Unnecessary `.first()` warning on `ch_sdrf` value channel
+- `--out` added to in-silico library generation to produce a log file with DIA-NN 2.3.2
+
+### `Dependencies`
+
+| Dependency            | Version   |
+| --------------------- | --------- |
+| `nextflow`            | >=25.04.0 |
+| `dia-nn`              | 1.8.1+    |
+| `thermorawfileparser` | 2.0.0.dev |
+| `sdrf-pipelines`      | 0.1.2     |
+| `pmultiqc`            | 0.0.43    |
+| `quantms-utils`       | 0.0.28    |
+
+---
+
 ## [1.0.0] bigbio/quantmsdiann - 2026-04-03
 
 Initial release of the standalone DIA-NN quantitative proteomics pipeline, refactored from [bigbio/quantms](https://github.com/bigbio/quantms).

--- a/nextflow.config
+++ b/nextflow.config
@@ -377,7 +377,7 @@ manifest {
     mainScript      = 'main.nf'
     defaultBranch   = 'main'
     nextflowVersion = '!>=25.04.0'
-    version         = '2.0.0dev'
+    version         = '2.0.0'
     doi             = '10.5281/zenodo.15573386'
 }
 


### PR DESCRIPTION
## Summary
- Bump manifest version from `2.0.0dev` to `2.0.0`
- Add comprehensive CHANGELOG entry for 2.0.0 (Rome) covering all features, changes, removals, and fixes since 1.0.0

Merge this to dev, then PR #36 (dev → main) is ready for release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)