### PR TITLE
Improve raw data file extension handling in input channel creation

### DIFF
--- a/subworkflows/local/create_input_channel/main.nf
+++ b/subworkflows/local/create_input_channel/main.nf
@@ -19,6 +19,11 @@ workflow CREATE_INPUT_CHANNEL {
         exit(1, "ERROR: Unsupported --local_input_type '${params.local_input_type}'. Supported values: ${allowedLocalInputTypes.join(', ')}")
     }
 
+    // Known raw-data extensions (order matters: strip longest/compound ones first
+    // so 'sample.d.zip' -> 'sample', not 'sample.d').
+    def knownRawExts = ['.d.tar.gz', '.d.tar', '.d.zip', '.mzML.gz', '.raw.gz',
+                        '.mzML', '.raw', '.dia', '.d']
+
     // Always parse as SDRF using DIA-NN converter
     SDRF_PARSING(ch_sdrf)
     ch_versions = ch_versions.mix(SDRF_PARSING.out.versions)
@@ -39,9 +44,19 @@ workflow CREATE_INPUT_CHANNEL {
             } else {
                 filestr = row.Filename.toString()
                 filestr = params.root_folder + File.separator + filestr
-                filestr = (params.local_input_type
-                    ? filestr.take(filestr.lastIndexOf('.')) + '.' + params.local_input_type
-                    : filestr)
+                if (params.local_input_type) {
+                    // Strip the longest matching known raw-data extension (covers
+                    // compound suffixes like .d.zip / .d.tar.gz from the SDRF),
+                    // then append the target extension.
+                    def stem = filestr
+                    def matched = knownRawExts.find { stem.endsWith(it) }
+                    if (matched) {
+                        stem = stem.substring(0, stem.length() - matched.length())
+                    } else if (stem.lastIndexOf('.') > 0) {
+                        stem = stem.take(stem.lastIndexOf('.'))
+                    }
+                    filestr = stem + '.' + params.local_input_type
+                }
             }
             return [filestr, experiment_id, row]
         }


### PR DESCRIPTION
## Description

This PR improves the handling of raw data file extensions when creating input channels, particularly for compound extensions like `.d.zip`, `.d.tar.gz`, and `.mzML.gz`.

### Changes

- Added a list of known raw-data file extensions (`knownRawExts`) ordered from longest to shortest to ensure compound suffixes are stripped correctly
- Refactored the file extension replacement logic to:
  - First attempt to match and strip the longest known raw-data extension
  - Fall back to the previous behavior (stripping at the last dot) if no known extension matches
  - Then append the target extension specified by `params.local_input_type`

### Motivation

The previous implementation used `lastIndexOf('.')` which would incorrectly handle files with compound extensions. For example, `sample.d.zip` would become `sample.d` instead of `sample` when converting to a different format. This fix ensures that known compound extensions are properly recognized and stripped as complete units.

### Testing

The change maintains backward compatibility with single-extension files while correctly handling compound extensions. Existing tests should continue to pass.

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/bigbio/quantmsdiann/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, also make a PR on the bigbio/quantmsdiann _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core pipelines lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).

https://claude.ai/code/session_01CtVkdv9sgCm6WUnfZxYrPr