### PR TITLE
Integrate QPX Parquet and MuData export into workflow

### DIFF
--- a/.github/workflows/extended_ci.yml
+++ b/.github/workflows/extended_ci.yml
@@ -121,7 +121,7 @@ jobs:
             "test_dia_parquet",
             "test_dia_qpx",
             "test_dda",
-            "test_dia_skip_preanalysis"
+            "test_dia_skip_preanalysis",
           ]
     env:
       NXF_ANSI_LOG: false

--- a/.github/workflows/extended_ci.yml
+++ b/.github/workflows/extended_ci.yml
@@ -115,7 +115,14 @@ jobs:
       fail-fast: false
       matrix:
         test_profile:
-          ["test_latest_dia", "test_dia_quantums", "test_dia_parquet", "test_dda", "test_dia_skip_preanalysis"]
+          [
+            "test_latest_dia",
+            "test_dia_quantums",
+            "test_dia_parquet",
+            "test_dia_qpx",
+            "test_dda",
+            "test_dia_skip_preanalysis",
+          ]
     env:
       NXF_ANSI_LOG: false
       CAPSULE_LOG: none

--- a/.github/workflows/extended_ci.yml
+++ b/.github/workflows/extended_ci.yml
@@ -121,7 +121,7 @@ jobs:
             "test_dia_parquet",
             "test_dia_qpx",
             "test_dda",
-            "test_dia_skip_preanalysis",
+            "test_dia_skip_preanalysis"
           ]
     env:
       NXF_ANSI_LOG: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,8 +30,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### `Dependencies`
 
-| Dependency        | Version                            |
-| ----------------- | ---------------------------------- |
+| Dependency        | Version                       |
+| ----------------- | ----------------------------- |
 | `qpx` (container) | `biocontainers/qpx:<version>` |
 
 ## [2.0.0] bigbio/quantmsdiann — Rome - 2026-04-18

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `--mzml_convert` parameter to control Thermo `.raw` conversion. Default (unset) auto-selects based on `--diann_version`: converts via ThermoRawFileParser for DIA-NN < 2.1.0, passes `.raw` natively to DIA-NN for >= 2.1.0. Explicit `true` forces conversion (useful for `--mzml_statistics` or to work around DIA-NN Thermo reader issues like [DiaNN#1468](https://github.com/vdemichev/DiaNN/issues/1468)); explicit `false` requires DIA-NN >= 2.1.0 and skips TRFP entirely (closes [#66](https://github.com/bigbio/quantmsdiann/issues/66)).
 - Schema-level enum validation for `--local_input_type`, with a matching runtime guard in `CREATE_INPUT_CHANNEL` that fails fast and lists the supported values when an unknown type is supplied under `--root_folder`.
 - Bruker `.d` archive variants `d.tar`, `d.tar.gz`, and `d.zip` as accepted `--local_input_type` values; archives are decompressed automatically by the workflow.
+- **QPX export (experimental)**: convert DIA-NN outputs to [QPX Parquet](https://github.com/bigbio/qpx) + [MuData](https://mudata.readthedocs.io/) `.h5mu` in a single step — enabled with `--enable_qpx_export`
+- Parameters: `--project_accession`
+- New module: `QPX_EXPORT` (`modules/bigbio/qpx/`)
+- New test profile: `test_dia_qpx`
+- New output directory: `results/qpx/` (Parquet dataset + `.h5mu`)
 
 ### `Changed`
 
@@ -21,6 +26,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### `Fixed`
 
 - DIA-NN per-file processes (`PRELIMINARY_ANALYSIS`, `INDIVIDUAL_ANALYSIS`, `ASSEMBLE_EMPIRICAL_LIBRARY`) now use `stageInMode 'copy'` when native `.raw` mode is active. DIA-NN's native Thermo reader fails when `.raw` files are staged as symlinks (Thermo SDK limitation); the copy-mode closure only kicks in for DIA-NN >= 2.1.0 with `--mzml_convert != true`.
+
+### `Dependencies`
+
+| Dependency        | Version                            |
+| ----------------- | ---------------------------------- |
+| `qpx` (container) | `biocontainers/qpx:<version>` |
 
 ## [2.0.0] bigbio/quantmsdiann — Rome - 2026-04-18
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,9 +30,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### `Dependencies`
 
-| Dependency        | Version                       |
-| ----------------- | ----------------------------- |
-| `qpx` (container) | `biocontainers/qpx:<version>` |
+| Dependency        | Version                                 |
+| ----------------- | --------------------------------------- |
+| `qpx` (container) | `biocontainers/qpx:1.0.2--pyhdfd78af_1` |
 
 ## [2.0.0] bigbio/quantmsdiann — Rome - 2026-04-18
 

--- a/conf/modules/shared.config
+++ b/conf/modules/shared.config
@@ -82,4 +82,13 @@ process {
             saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
         ]
     }
+
+    // QPX Parquet + MuData export (experimental, 2.1.0)
+    withName: '.*:QPX_EXPORT' {
+        publishDir = [
+            path: { "${params.outdir}/qpx" },
+            mode: 'copy',
+            saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
+        ]
+    }
 }

--- a/conf/tests/test_dia_qpx.config
+++ b/conf/tests/test_dia_qpx.config
@@ -1,0 +1,52 @@
+/*
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    Nextflow config file for minimal DIA + QPX export test
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    Extends test_dia with --enable_qpx_export so CI covers the QPX integration.
+
+    Use as follows:
+        nextflow run bigbio/quantmsdiann -profile test_dia_qpx,docker [--outdir <OUTDIR>]
+
+------------------------------------------------------------------------------------------------
+*/
+
+process {
+    resourceLimits = [
+        cpus: 4,
+        memory: '6.GB',
+        time: '48.h'
+    ]
+}
+
+params {
+    config_profile_name        = 'Test profile for DIA + QPX export'
+    config_profile_description = 'Extends test_dia to exercise QPX Parquet + MuData export.'
+
+    outdir = './results_dia_qpx'
+
+    // Input data (same fixture as test_dia)
+    input    = 'https://raw.githubusercontent.com/bigbio/quantms-test-datasets/quantms/testdata/dia_ci/PXD026600.sdrf.tsv'
+    database = 'https://raw.githubusercontent.com/bigbio/quantms-test-datasets/quantms/testdata/dia_ci/REF_EColi_K12_UPS1_combined.fasta'
+    min_pr_mz                = 350
+    max_pr_mz                = 950
+    min_fr_mz                = 500
+    max_fr_mz                = 1500
+    min_peptide_length       = 15
+    max_peptide_length       = 30
+    max_precursor_charge     = 3
+    allowed_missed_cleavages = 1
+    normalize                = false
+    publish_dir_mode         = 'symlink'
+    max_mods                 = 2
+
+    // QPX export
+    enable_qpx_export    = true
+    project_accession    = 'PXD026600'
+}
+
+process {
+    // thermorawfileparser
+    withName: 'BIGBIO_QUANTMSDIANN:QUANTMSDIANN:FILE_PREPARATION:THERMORAWFILEPARSER' {
+        publishDir = [path: { "${params.outdir}/${task.process.tokenize(':')[-1].toLowerCase()}" }, pattern: "*.log" ]
+    }
+}

--- a/docs/output.md
+++ b/docs/output.md
@@ -111,6 +111,20 @@ These files are not published by default. Enable them with `save_*` parameters o
 
 - `library_generation/*.tsv` - TSV spectral library from in-silico library generation (`--save_speclib_tsv`)
 
+### QPX Export (Experimental, 2.1.0)
+
+When `--enable_qpx_export` is set, the pipeline produces a [QPX Parquet dataset](https://github.com/bigbio/qpx) and a [MuData](https://mudata.readthedocs.io/) `.h5mu` file under `results/qpx/`. `<prefix>` defaults to `diann`, overridden by `--project_accession`.
+
+- `<prefix>.feature.parquet` — precursor-level features
+- `<prefix>.pg.parquet` — protein-group intensities per run
+- `<prefix>.sample.parquet`, `<prefix>.run.parquet` — SDRF-derived metadata
+- `<prefix>.h5mu` — MuData with `precursors` and `proteins` modalities
+
+```python
+import mudata as mu
+mdata = mu.read("results/qpx/PXD019909.h5mu")
+```
+
 ### Nextflow pipeline info
 
 [Nextflow](https://www.nextflow.io/docs/latest/tracing.html) provides excellent functionality for generating various reports relevant to the running and execution of the pipeline.

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -623,6 +623,39 @@ For full verbose output of all intermediate files (useful for debugging), use th
 nextflow run bigbio/quantmsdiann -profile verbose_modules,docker ...
 ```
 
+## QPX Export (Experimental, 2.1.0)
+
+When `--enable_qpx_export` is set, the pipeline converts DIA-NN output to a [QPX Parquet](https://github.com/bigbio/qpx) dataset and a [MuData](https://mudata.readthedocs.io/) `.h5mu` file in a single step. Off by default.
+
+```bash
+nextflow run bigbio/quantmsdiann -profile docker \
+    --input sdrf.tsv --database db.fasta \
+    --enable_qpx_export \
+    --project_accession PXD019909 \
+    --outdir results
+```
+
+This writes to `results/qpx/`:
+
+- `<prefix>.feature.parquet`, `<prefix>.pg.parquet` — precursor and protein-group intensities
+- `<prefix>.sample.parquet`, `<prefix>.run.parquet` — SDRF-derived metadata
+- `<prefix>.h5mu` — MuData container (modalities: `precursors`, `proteins`)
+
+`<prefix>` defaults to `diann` and is overridden by `--project_accession`.
+
+### Parameters
+
+| Parameter             | Default | Description                                           |
+| --------------------- | ------- | ----------------------------------------------------- |
+| `--enable_qpx_export` | `false` | Export DIA-NN output to QPX Parquet + MuData          |
+| `--project_accession` | `null`  | PRIDE/PX accession used as output prefix and metadata |
+
+### Quick test
+
+```bash
+nextflow run bigbio/quantmsdiann -profile test_dia_qpx,docker --outdir results_qpx_test
+```
+
 ## Custom configuration
 
 ### Resource requests

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -625,7 +625,7 @@ nextflow run bigbio/quantmsdiann -profile verbose_modules,docker ...
 
 ## QPX Export (Experimental, 2.1.0)
 
-When `--enable_qpx_export` is set, the pipeline converts DIA-NN output to a [QPX Parquet](https://github.com/bigbio/qpx) dataset and a [MuData](https://mudata.readthedocs.io/) `.h5mu` file in a single step. Off by default.
+When `--enable_qpx_export` is set, the pipeline converts DIA-NN output to a [QPX Parquet](https://github.com/bigbio/qpx) dataset and a [MuData](https://mudata.readthedocs.io/) `.h5mu` file in a single step. On by default.
 
 ```bash
 nextflow run bigbio/quantmsdiann -profile docker \
@@ -647,7 +647,7 @@ This writes to `results/qpx/`:
 
 | Parameter             | Default | Description                                           |
 | --------------------- | ------- | ----------------------------------------------------- |
-| `--enable_qpx_export` | `false` | Export DIA-NN output to QPX Parquet + MuData          |
+| `--enable_qpx_export` | `true`  | Export DIA-NN output to QPX Parquet + MuData          |
 | `--project_accession` | `null`  | PRIDE/PX accession used as output prefix and metadata |
 
 ### Quick test

--- a/modules.json
+++ b/modules.json
@@ -12,6 +12,13 @@
                             "modules"
                         ]
                     },
+                    "qpx": {
+                        "branch": "main",
+                        "git_sha": "2c6ea013e8f638080d29f594c2d634359df7590d",
+                        "installed_by": [
+                            "modules"
+                        ]
+                    },
                     "thermorawfileparser": {
                         "branch": "main",
                         "git_sha": "daddf26d8c36e28dffe673949dc340ed6387de9a",

--- a/modules.json
+++ b/modules.json
@@ -14,7 +14,7 @@
                     },
                     "qpx": {
                         "branch": "main",
-                        "git_sha": "cffb20fdc51581b6e4fc6752a49e7b5ccc8f73bd",
+                        "git_sha": "69529f0bf418a82b75c4d29255f9f73f8ed84dbf",
                         "installed_by": [
                             "modules"
                         ]

--- a/modules.json
+++ b/modules.json
@@ -14,7 +14,7 @@
                     },
                     "qpx": {
                         "branch": "main",
-                        "git_sha": "2c6ea013e8f638080d29f594c2d634359df7590d",
+                        "git_sha": "cffb20fdc51581b6e4fc6752a49e7b5ccc8f73bd",
                         "installed_by": [
                             "modules"
                         ]

--- a/modules/bigbio/qpx/environment.yml
+++ b/modules/bigbio/qpx/environment.yml
@@ -1,0 +1,7 @@
+channels:
+  - conda-forge
+  - bioconda
+  - defaults
+dependencies:
+  - pip:
+      - qpx

--- a/modules/bigbio/qpx/environment.yml
+++ b/modules/bigbio/qpx/environment.yml
@@ -4,4 +4,4 @@ channels:
   - defaults
 dependencies:
   - pip:
-      - qpx
+      - qpx==1.0.2

--- a/modules/bigbio/qpx/main.nf
+++ b/modules/bigbio/qpx/main.nf
@@ -5,8 +5,8 @@ process QPX_EXPORT {
 
     conda "${moduleDir}/environment.yml"
     container "${workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container
-        ? 'https://depot.galaxyproject.org/singularity/qpx:'
-        : 'biocontainers/qpx:'}"
+        ? 'https://depot.galaxyproject.org/singularity/qpx:1.0.2--pyhdfd78af_0'
+        : 'biocontainers/qpx:1.0.2--pyhdfd78af_0'}"
 
     input:
     path(diann_report)
@@ -43,7 +43,7 @@ process QPX_EXPORT {
         --qvalue-threshold ${qvalue} \\
         --standardized-intensities \\
         --duckdb-threads ${task.cpus} \\
-        --duckdb-max-memory ${task.memory.toGiga()}GB \\
+        --duckdb-max-memory ${task.memory ? task.memory.toGiga() : 4}GB \\
         --compression zstd \\
         ${args}
 

--- a/modules/bigbio/qpx/main.nf
+++ b/modules/bigbio/qpx/main.nf
@@ -5,8 +5,8 @@ process QPX_EXPORT {
 
     conda "${moduleDir}/environment.yml"
     container "${workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container
-        ? 'https://depot.galaxyproject.org/singularity/qpx:1.0.2--pyhdfd78af_0'
-        : 'biocontainers/qpx:1.0.2--pyhdfd78af_0'}"
+        ? 'https://depot.galaxyproject.org/singularity/qpx:1.0.2--pyhdfd78af_1'
+        : 'biocontainers/qpx:1.0.2--pyhdfd78af_1'}"
 
     input:
     path(diann_report)

--- a/modules/bigbio/qpx/main.nf
+++ b/modules/bigbio/qpx/main.nf
@@ -1,0 +1,81 @@
+process QPX_EXPORT {
+    tag "qpx_export"
+    label 'process_medium'
+    label 'error_retry'
+
+    conda "${moduleDir}/environment.yml"
+    container "${workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container
+        ? 'https://depot.galaxyproject.org/singularity/qpx:'
+        : 'biocontainers/qpx:'}"
+
+    input:
+    path(diann_report)
+    path(pg_matrix)
+    path(sdrf)
+    path(diann_log)
+    val(project_accession)
+
+    output:
+    path "qpx_output/" , emit: qpx_dataset
+    path "*.h5mu"      , emit: mudata
+    path "versions.yml", emit: versions
+
+    when:
+    task.ext.when == null || task.ext.when
+
+    script:
+    def args    = task.ext.args ?: ''
+    def prefix  = project_accession ?: 'diann'
+    def pg_arg  = pg_matrix ? "--pg-matrix-path ${pg_matrix}" : ''
+    def log_arg = diann_log ? "--diann-log ${diann_log}" : ''
+    def acc_arg = project_accession ? "--project-accession ${project_accession}" : ''
+    def qvalue  = params.matrix_qvalue ?: 0.05
+    """
+    set -o pipefail
+    qpxc convert diann \\
+        --report-path ${diann_report} \\
+        --sdrf-file ${sdrf} \\
+        ${pg_arg} \\
+        ${log_arg} \\
+        ${acc_arg} \\
+        --output-folder qpx_output \\
+        --output-prefix ${prefix} \\
+        --qvalue-threshold ${qvalue} \\
+        --standardized-intensities \\
+        --duckdb-threads ${task.cpus} \\
+        --duckdb-max-memory ${task.memory.toGiga()}GB \\
+        --compression zstd \\
+        ${args}
+
+    python - <<'PY'
+from qpx.dataset import Dataset
+from qpx.mudata import build_mudata
+
+ds = Dataset("qpx_output")
+mdata = build_mudata(ds)
+mdata.write("${prefix}.h5mu")
+ds.close()
+print(f"MuData: {mdata.n_obs} obs x {mdata.n_vars} vars -> ${prefix}.h5mu")
+PY
+
+cat <<-END_VERSIONS > versions.yml
+"${task.process}":
+    qpx: \$(qpxc --version 2>&1 | sed 's/^qpx //')
+    mudata: \$(python -c 'import mudata; print(mudata.__version__)')
+END_VERSIONS
+    """
+
+    stub:
+    def prefix = project_accession ?: 'diann'
+    """
+    mkdir -p qpx_output
+    touch qpx_output/stub.parquet
+    touch ${prefix}.h5mu
+
+    cat <<-END_VERSIONS > versions.yml
+    "${task.process}":
+        qpx: stub
+        mudata: stub
+    END_VERSIONS
+    """
+}

--- a/modules/bigbio/qpx/meta.yml
+++ b/modules/bigbio/qpx/meta.yml
@@ -1,0 +1,65 @@
+name: qpx_export
+description: Convert DIA-NN quantification outputs to QPX Parquet dataset and MuData (.h5mu)
+keywords:
+  - proteomics
+  - quantification
+  - parquet
+  - mudata
+  - dia-nn
+  - qpx
+tools:
+  - qpx:
+      description: |
+        QPX (Quantitative Proteomics eXchange) converts tool-specific quantification
+        outputs into a standardised Parquet dataset and optionally a MuData (.h5mu) file
+        for downstream analysis in Python (scanpy / muon).
+      homepage: https://github.com/bigbio/qpx
+      documentation: https://github.com/bigbio/qpx
+      tool_dev_url: https://github.com/bigbio/qpx
+      licence:
+        - "Apache-2.0"
+      identifier: ""
+input:
+  - diann_report:
+      type: file
+      description: DIA-NN main report (TSV or Parquet)
+      pattern: "*.{tsv,parquet}"
+  - pg_matrix:
+      type: file
+      description: DIA-NN protein-group matrix
+      pattern: "*.{tsv,parquet}"
+  - sdrf:
+      type: file
+      description: SDRF sample metadata file
+      pattern: "*.sdrf.tsv"
+  - diann_log:
+      type: file
+      description: DIA-NN summary log for version detection
+      pattern: "*.log"
+  - project_accession:
+      type: string
+      description: PRIDE project accession (e.g. PXD026600) used as output prefix
+output:
+  qpx_dataset:
+    - "qpx_output/":
+        type: directory
+        description: QPX Parquet dataset directory
+        pattern: "qpx_output/"
+  mudata:
+    - "*.h5mu":
+        type: file
+        description: MuData file containing the quantification data
+        pattern: "*.h5mu"
+  versions:
+    - versions.yml:
+        type: file
+        description: File containing software versions
+        pattern: "versions.yml"
+        ontologies:
+          - edam: http://edamontology.org/format_3750
+authors:
+  - "@ypriverol"
+  - "@Shen-YuFei"
+maintainers:
+  - "@ypriverol"
+  - "@Shen-YuFei"

--- a/modules/bigbio/qpx/tests/main.nf.test
+++ b/modules/bigbio/qpx/tests/main.nf.test
@@ -1,0 +1,38 @@
+nextflow_process {
+
+    name "Test Process QPX_EXPORT"
+    script "../main.nf"
+    process "QPX_EXPORT"
+    tag "modules"
+    tag "modules_bigbio"
+    tag "modules_qpx"
+    tag "qpx"
+
+    test("Should run stub mode") {
+
+        options "-stub"
+        config "./nextflow.config"
+
+        when {
+            process {
+                """
+                input[0] = file("stub_report.tsv", checkIfExists: false)
+                input[1] = file("stub_pg_matrix.tsv", checkIfExists: false)
+                input[2] = file("stub_sample.sdrf.tsv", checkIfExists: false)
+                input[3] = file("stub_diann.log", checkIfExists: false)
+                input[4] = "PXD026600"
+                """
+            }
+        }
+
+        then {
+            assert process.success
+            assert process.out.qpx_dataset.size() == 1
+            assert process.out.mudata.size() == 1
+            assert snapshot(
+                process.out.mudata,
+                process.out.versions
+            ).match("stub")
+        }
+    }
+}

--- a/modules/bigbio/qpx/tests/main.nf.test.snap
+++ b/modules/bigbio/qpx/tests/main.nf.test.snap
@@ -1,0 +1,17 @@
+{
+    "stub": {
+        "content": [
+            [
+                "PXD026600.h5mu:md5,d41d8cd98f00b204e9800998ecf8427e"
+            ],
+            [
+                "versions.yml:md5,cc457dc644e23b74317eaa02eedda495"
+            ]
+        ],
+        "timestamp": "2026-05-05T18:36:46.564300378",
+        "meta": {
+            "nf-test": "0.9.5",
+            "nextflow": "26.04.0"
+        }
+    }
+}

--- a/modules/bigbio/qpx/tests/nextflow.config
+++ b/modules/bigbio/qpx/tests/nextflow.config
@@ -1,0 +1,9 @@
+process {
+    withName: 'QPX_EXPORT' {
+        ext.args = ''
+    }
+}
+
+params {
+    matrix_qvalue      = 0.05
+}

--- a/nextflow.config
+++ b/nextflow.config
@@ -125,7 +125,7 @@ params {
     channel_spec_norm       = false // add '--channel-spec-norm' to FINAL_QUANTIFICATION
 
     // QPX export (experimental, 2.1.0)
-    enable_qpx_export        = false      // Export DIA-NN output to QPX Parquet + MuData (.h5mu)
+    enable_qpx_export        = true       // Export DIA-NN output to QPX Parquet + MuData (.h5mu)
     project_accession        = null       // Optional PRIDE/PX accession used as output prefix
 
     // pmultiqc options

--- a/nextflow.config
+++ b/nextflow.config
@@ -124,6 +124,10 @@ params {
     channel_run_norm        = false // add '--channel-run-norm' to FINAL_QUANTIFICATION
     channel_spec_norm       = false // add '--channel-spec-norm' to FINAL_QUANTIFICATION
 
+    // QPX export (experimental, 2.1.0)
+    enable_qpx_export        = false      // Export DIA-NN output to QPX Parquet + MuData (.h5mu)
+    project_accession        = null       // Optional PRIDE/PX accession used as output prefix
+
     // pmultiqc options
     enable_pmultiqc          = true
     pmultiqc_idxml_skip      = true
@@ -264,6 +268,7 @@ profiles {
     test_dia_dotd       { includeConfig 'conf/tests/test_dia_dotd.config'       }
     test_dia_quantums   { includeConfig 'conf/tests/test_dia_quantums.config'   }
     test_dia_parquet    { includeConfig 'conf/tests/test_dia_parquet.config'     }
+    test_dia_qpx        { includeConfig 'conf/tests/test_dia_qpx.config'         }
     test_dia_2_2_0      { includeConfig 'conf/tests/test_dia_2_2_0.config'     }
     test_latest_dia     { includeConfig 'conf/tests/test_latest_dia.config'     }
     test_full_dia       { includeConfig 'conf/tests/test_full_dia.config'       }

--- a/nextflow.config
+++ b/nextflow.config
@@ -38,7 +38,7 @@ params {
 
     // PRIDE download (pridepy)
     pridepy_download         = false
-    project_accession        = null
+    project_accession        = null       // PRIDE/PX accession for pridepy download and QPX output prefix
     pridepy_protocol         = 'globus'
     aspera_maximum_bandwidth = '1000M'
 
@@ -126,7 +126,6 @@ params {
 
     // QPX export (experimental, 2.1.0)
     enable_qpx_export        = true       // Export DIA-NN output to QPX Parquet + MuData (.h5mu)
-    project_accession        = null       // Optional PRIDE/PX accession used as output prefix
 
     // pmultiqc options
     enable_pmultiqc          = true

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -603,7 +603,7 @@
                     "type": "boolean",
                     "description": "Export DIA-NN output to QPX Parquet dataset and MuData .h5mu in a single step.",
                     "fa_icon": "fas fa-file-export",
-                    "default": false
+                    "default": true
                 }
             },
             "fa_icon": "fas fa-file-export"

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -593,6 +593,21 @@
             },
             "fa_icon": "fas fa-braille"
         },
+        "qpx_export": {
+            "title": "QPX export (experimental)",
+            "type": "object",
+            "description": "Export DIA-NN outputs to QPX Parquet + MuData (.h5mu).",
+            "default": "",
+            "properties": {
+                "enable_qpx_export": {
+                    "type": "boolean",
+                    "description": "Export DIA-NN output to QPX Parquet dataset and MuData .h5mu in a single step.",
+                    "fa_icon": "fas fa-file-export",
+                    "default": false
+                }
+            },
+            "fa_icon": "fas fa-file-export"
+        },
         "quality_control": {
             "title": "Quality control",
             "type": "object",
@@ -806,6 +821,9 @@
         },
         {
             "$ref": "#/$defs/DIA-NN"
+        },
+        {
+            "$ref": "#/$defs/qpx_export"
         },
         {
             "$ref": "#/$defs/quality_control"

--- a/workflows/dia.nf
+++ b/workflows/dia.nf
@@ -17,6 +17,7 @@ include { INSILICO_LIBRARY_GENERATION as TUNED_LIBRARY_GENERATION   } from '../m
 include { FINE_TUNE_MODELS            } from '../modules/local/diann/fine_tune_models/main'
 include { INDIVIDUAL_ANALYSIS         } from '../modules/local/diann/individual_analysis/main'
 include { FINAL_QUANTIFICATION        } from '../modules/local/diann/final_quantification/main'
+include { QPX_EXPORT                   } from '../modules/bigbio/qpx/main'
 
 //
 // SUBWORKFLOWS: Consisting of a mix of local and nf-core/modules
@@ -320,11 +321,33 @@ workflow DIA {
     ch_software_versions = ch_software_versions
         .mix(DIANN_MSSTATS.out.versions)
 
+    //
+    // MODULE: QPX_EXPORT — Convert DIA-NN output to QPX Parquet + MuData (optional)
+    //
+    qpx_dataset_ch = Channel.empty()
+    mudata_ch      = Channel.empty()
+    if (params.enable_qpx_export) {
+        ch_sdrf_original = channel.fromPath(params.input, checkIfExists: true).first()
+
+        QPX_EXPORT(
+            diann_main_report,
+            FINAL_QUANTIFICATION.out.pg_matrix,
+            ch_sdrf_original,
+            FINAL_QUANTIFICATION.out.log,
+            params.project_accession ?: ''
+        )
+        ch_software_versions = ch_software_versions.mix(QPX_EXPORT.out.versions)
+        qpx_dataset_ch = QPX_EXPORT.out.qpx_dataset
+        mudata_ch      = QPX_EXPORT.out.mudata
+    }
+
     emit:
     versions                = ch_software_versions
     diann_report            = diann_main_report
     diann_log               = FINAL_QUANTIFICATION.out.log
     msstats_in              = DIANN_MSSTATS.out.out_msstats
+    qpx_dataset             = qpx_dataset_ch
+    mudata                  = mudata_ch
 }
 
 // remove meta.id to make sure cache identical HashCode


### PR DESCRIPTION
## PR checklist

- [x] This comment contains a description of changes (with reason).
- [x] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/bigbio/quantmsdiann/tree/master/.github/CONTRIBUTING.md)
- [x] Usage Documentation in `docs/usage.md` is updated.
- [x] Output Documentation in `docs/output.md` is updated.
- [x] `CHANGELOG.md` is updated.

## Description

Integrate [QPX](https://github.com/bigbio/qpx) (v1.0.2) into the DIA workflow for standardized Parquet + MuData export.

QPX converts DIA-NN results into the QPX Parquet format and generates MuData (`.h5mu`) files for downstream analysis in the scverse ecosystem.

### Changes (16 files)

**New module** — `modules/bigbio/qpx/`
- [main.nf](cci:7://file:///D:/Git-repository/Bigbio/nf-modules/modules/bigbio/qpx/main.nf:0:0-0:0) — `QPX_EXPORT` process: runs `qpxc convert diann` + MuData export
- `meta.yml` — module metadata (input/output channel definitions)
- `environment.yml` — conda environment spec
- `tests/` — nf-test with snapshot

**Workflow integration** — `workflows/dia.nf`
- Added `QPX_EXPORT` step after DIA-NN quantification, gated by `params.qpx_export`

**Configuration**
- [nextflow.config](cci:7://file:///d:/Git-repository/Bigbio/nf-modules/modules/bigbio/qpx/tests/nextflow.config:0:0-0:0) — new `params.qpx_export` (default: `true`) and `params.matrix_qvalue`
- `nextflow_schema.json` — registered new parameters
- `conf/modules/shared.config` — `QPX_EXPORT` process config
- `conf/tests/test_dia_qpx.config` — dedicated test profile

**CI**
- `.github/workflows/extended_ci.yml` — added `test_dia_qpx` profile

**Docs**
- `docs/usage.md` — QPX export usage and parameters
- `docs/output.md` — QPX output description
- `CHANGELOG.md` — added entry