### PR TITLE
docs: DIA-NN container licensing + local build (add 2.5.0); open 2.2.0dev

### DIFF
--- a/.nf-core.yml
+++ b/.nf-core.yml
@@ -28,4 +28,4 @@ template:
   name: quantmsdiann
   org: bigbio
   outdir: .
-  version: 2.1.0
+  version: 2.2.0dev

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.2.0dev] bigbio/quantmsdiann
+
+### `Changed`
+
+- Documentation: clarified DIA-NN container licensing. Only DIA-NN 1.8.1 is publicly redistributable (pulled from BioContainers as the default); releases from 1.9 onward must be built locally from the [quantms-containers](https://github.com/bigbio/quantms-containers) recipes and tagged `ghcr.io/bigbio/diann:<version>` so the matching `-profile diann_v<version>` resolves them. Added the missing DIA-NN 2.5.0 row to the README support table.
+
 ## [2.1.0] bigbio/quantmsdiann — Sao Pablo - 2026-05-05
 
 ### `Added`

--- a/README.md
+++ b/README.md
@@ -42,8 +42,30 @@ The pipeline takes [SDRF](https://github.com/bigbio/proteomics-metadata-standard
 | 2.1.0           | `diann_v2_1_0` | `ghcr.io/bigbio/diann:2.1.0`               | Native .raw support, Parquet output            |
 | 2.2.0           | `diann_v2_2_0` | `ghcr.io/bigbio/diann:2.2.0`               | Speed optimizations (up to 1.6x on HPC)        |
 | 2.3.2           | `diann_v2_3_2` | `ghcr.io/bigbio/diann:2.3.2`               | DDA support (beta), InfinDIA, up to 9 var mods |
+| 2.5.0           | `diann_v2_5_0` | `ghcr.io/bigbio/diann:2.5.0`               | +70% protein IDs, DL model selection flags     |
 
 Switch versions with e.g. `-profile diann_v2_2_0,docker`. See the [DIA-NN Version Selection](docs/usage.md#dia-nn-version-selection) guide and [full parameter reference](docs/parameters.md) for details.
+
+> [!IMPORTANT]
+> **DIA-NN licensing.** Only **DIA-NN 1.8.1** is redistributable and is pulled
+> automatically from the public BioContainers image
+> (`docker.io/biocontainers/diann:v1.8.1_cv1`), so the default profile works out
+> of the box. The DIA-NN license does **not** permit redistribution of releases
+> from 1.9 onward, so the `ghcr.io/bigbio/diann:*` images above are **not
+> public** — with a valid DIA-NN download you build them locally from the
+> [`quantms-containers`](https://github.com/bigbio/quantms-containers) recipes:
+>
+> ```bash
+> git clone https://github.com/bigbio/quantms-containers
+> cd quantms-containers/diann-2.5.0
+> docker build -t ghcr.io/bigbio/diann:2.5.0 .          # Docker
+> # or, for Singularity/Apptainer:
+> singularity build diann-2.5.0.sif docker-daemon://ghcr.io/bigbio/diann:2.5.0
+> ```
+>
+> The image **must** be tagged `ghcr.io/bigbio/diann:<version>` (matching the
+> `Container` column) for the matching `-profile diann_v<version>` to pick it up
+> automatically.
 
 ## Quick start
 

--- a/conf/tests/test_dia_dotd.config
+++ b/conf/tests/test_dia_dotd.config
@@ -27,7 +27,7 @@ params {
 
     // Input data
     input    = 'https://raw.githubusercontent.com/bigbio/quantms-test-datasets/quantms/testdata/dia_ci_dotd/PXD065380.sdrf.tsv'
-    database = 'https://raw.githubusercontent.com/bigbio/quantms-test-datasets/quantms/databases/PXD065380.fasta'
+    database = 'https://raw.githubusercontent.com/bigbio/quantms-test-datasets/quantms/databases/PXD065380/PXD065380.fasta'
 
     min_pr_mz = 350
     max_pr_mz = 950

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -204,6 +204,15 @@ The default DIA-NN version is 1.8.1. To use a different version:
 
 Example: `nextflow run bigbio/quantmsdiann -profile test_dia,docker,diann_v2_2_0`
 
+> [!IMPORTANT]
+> DIA-NN's license only permits public redistribution of **version 1.8.1**, which
+> is pulled automatically from BioContainers (`docker.io/biocontainers/diann:v1.8.1_cv1`).
+> Containers for **1.9 and later are not public**: build them locally from the
+> [`quantms-containers`](https://github.com/bigbio/quantms-containers) recipes and
+> tag the image `ghcr.io/bigbio/diann:<version>` so the matching
+> `-profile diann_v<version>` resolves it, e.g.
+> `cd quantms-containers/diann-2.5.0 && docker build -t ghcr.io/bigbio/diann:2.5.0 .`
+
 ### Verbose Module Output
 
 Use `-profile verbose_modules` to publish intermediate files from all pipeline steps:

--- a/nextflow.config
+++ b/nextflow.config
@@ -405,7 +405,7 @@ manifest {
     mainScript      = 'main.nf'
     defaultBranch   = 'main'
     nextflowVersion = '!>=25.10.4'
-    version         = '2.1.0'
+    version         = '2.2.0dev'
     doi             = '10.5281/zenodo.15573386'
 }
 


### PR DESCRIPTION
Targets `dev`.

## Docs (container licensing)
The `Supported DIA-NN Versions` table and `docs/usage.md` implied the `ghcr.io/bigbio/diann:*` images are directly pullable. They are **not public** — DIA-NN's license only permits redistribution of **1.8.1** (the default, from BioContainers). This clarifies:
- Build 1.9+ locally from [`quantms-containers`](https://github.com/bigbio/quantms-containers) and tag `ghcr.io/bigbio/diann:<version>` so `-profile diann_v<version>` resolves it automatically.
- Added the missing **2.5.0** row to the README support table (already present in docs/usage.md and `conf/diann_versions/v2_5_0.config`).

## Version
- Bump pipeline version `2.1.0` → **`2.2.0dev`** (`nextflow.config` manifest + `.nf-core.yml`), open a `2.2.0dev` CHANGELOG section.

Docs + version metadata only; no code/config logic changes.