### PR TITLE
fix(diann): benchmark-review bug fixes (--kb, QuantUMS, mass-accuracy, --no-prot-inf)

### DIFF
--- a/lib/BlockedFlags.groovy
+++ b/lib/BlockedFlags.groovy
@@ -71,6 +71,8 @@ class BlockedFlags {
             '--quick-mass-acc', '--min-corr', '--corr-diff', '--time-corr-only',
             '--min-pr-mz', '--max-pr-mz', '--min-fr-mz', '--max-fr-mz',
             '--channel-run-norm', '--channel-spec-norm',
+            // Pipeline-managed: Enterprise Knowledge Base, gated by params.enable_kb
+            '--kb',
             // Pipeline-managed: preliminary step disables protein inference (--no-prot-inf)
             '--no-prot-inf',
         ],
@@ -85,6 +87,8 @@ class BlockedFlags {
             // (--gen-spec-lib produces a spectral library, not a quantified report).
             // Blocked to prevent users from thinking they affect this step.
             '--no-prot-inf', '--relaxed-prot-inf', '--pg-level',
+            // Pipeline-managed: Enterprise Knowledge Base, gated by params.enable_kb
+            '--kb',
         ],
         INDIVIDUAL_ANALYSIS: [
             // Pipeline-managed: set from params and calibrated values from assembly step
@@ -96,13 +100,18 @@ class BlockedFlags {
             '--min-pr-mz', '--max-pr-mz', '--min-fr-mz', '--max-fr-mz',
             '--channel-run-norm', '--channel-spec-norm',
             '--no-prot-inf',
+            // Pipeline-managed: Enterprise Knowledge Base, gated by params.enable_kb
+            '--kb',
         ],
         FINAL_QUANTIFICATION: [
             // Pipeline-managed: set from params for final report generation
             '--no-main-report', '--gen-spec-lib', '--out-lib', '--no-ifs-removal',
             '--use-quant', '--matrices', '--out',
-            // Pipeline-managed: protein inference (--relaxed-prot-inf --pg-level)
+            // Pipeline-managed: protein inference is --no-prot-inf (blocked below); --relaxed-prot-inf
+            // also blocked so extra_args can't re-enable relaxed inference, plus --pg-level.
             '--relaxed-prot-inf', '--pg-level',
+            // Pipeline-managed: QuantUMS quantification (params.quantums and quantums_* params)
+            '--direct-quant', '--quant-sel-runs', '--quant-train-runs', '--quant-params',
             // Pipeline-managed: FDR controls (precursor_qvalue, matrix_qvalue, matrix_spec_q)
             '--qvalue', '--matrix-qvalue', '--matrix-spec-q',
             '--window', '--individual-windows',

--- a/modules/local/diann/assemble_empirical_library/main.nf
+++ b/modules/local/diann/assemble_empirical_library/main.nf
@@ -33,6 +33,9 @@ process ASSEMBLE_EMPIRICAL_LIBRARY {
     def args = task.ext.args ?: ''
     // DIA-NN Enterprise license; falls back to a key next to the binary when no path is provided
     def license_arg = diann_license ? "--license ${diann_license}" : ""
+    // DIA-NN Enterprise: Knowledge Base (--kb) on the first-pass search that builds the
+    // empirical library — this is the main identification pass, so --kb belongs here.
+    def kb = params.enable_kb ? "--kb" : ""
     // Strip flags managed by the pipeline from extra_args to prevent silent conflicts.
     // Blocked flags are defined centrally in lib/BlockedFlags.groovy — edit there, not here.
     args = BlockedFlags.strip('ASSEMBLE_EMPIRICAL_LIBRARY', args, log)
@@ -80,6 +83,7 @@ process ASSEMBLE_EMPIRICAL_LIBRARY {
             ${scoring_mode} \\
             ${aa_eq} \\
             ${license_arg} \\
+            ${kb} \\
             ${diann_tims_sum} \\
             ${diann_im_window} \\
             ${diann_dda_flag} \\

--- a/modules/local/diann/final_quantification/main.nf
+++ b/modules/local/diann/final_quantification/main.nf
@@ -55,11 +55,15 @@ process FINAL_QUANTIFICATION {
     no_norm = params.normalize ? "" : "--no-norm"
     report_decoys = params.report_decoys ? "--report-decoys": ""
     diann_export_xic = params.export_xic ? "--xic": ""
-    // --direct-quant exists in DIA-NN >= 1.9.2 (QuantUMS counterpart); skip for older versions
+    // QuantUMS is DIA-NN's recommended quant for >= 1.9.2; --direct-quant opts out to legacy quant.
+    quantums_on = params.quantums && VersionUtils.versionAtLeast(params.diann_version, '1.9.2')
     quantums = params.quantums ? "" : (VersionUtils.versionAtLeast(params.diann_version, '1.9.2') ? "--direct-quant" : "")
-    quantums_train_runs = params.quantums_train_runs ? "--quant-train-runs $params.quantums_train_runs": ""
-    quantums_sel_runs = params.quantums_sel_runs ? "--quant-sel-runs $params.quantums_sel_runs": ""
-    quantums_params = params.quantums_params ? "--quant-params $params.quantums_params": ""
+    // QuantUMS tuning flags only apply when QuantUMS is active — older versions don't support them.
+    // --quant-sel-runs caps QuantUMS parameter optimisation to N auto-selected runs, which keeps
+    // QuantUMS fast on large cohorts (thousands of runs) where optimising over every run is very slow.
+    quantums_train_runs = (quantums_on && params.quantums_train_runs) ? "--quant-train-runs $params.quantums_train_runs": ""
+    quantums_sel_runs = (quantums_on && params.quantums_sel_runs) ? "--quant-sel-runs $params.quantums_sel_runs": ""
+    quantums_params = (quantums_on && params.quantums_params) ? "--quant-params $params.quantums_params": ""
     scoring_mode = params.scoring_mode == 'proteoforms' ? '--proteoforms' :
                          params.scoring_mode == 'peptidoforms' ? '--peptidoforms' : ''
     aa_eq = params.aa_eq ? '--aa-eq' : ''

--- a/modules/local/diann/final_quantification/main.nf
+++ b/modules/local/diann/final_quantification/main.nf
@@ -91,7 +91,7 @@ process FINAL_QUANTIFICATION {
             --threads ${task.cpus} \\
             --verbose $params.debug_level \\
             --temp ./quant/ \\
-            --relaxed-prot-inf \\
+            --no-prot-inf \\
             --pg-level $params.pg_level \\
             ${species_genes} \\
             ${no_norm} \\

--- a/modules/local/diann/individual_analysis/main.nf
+++ b/modules/local/diann/individual_analysis/main.nf
@@ -84,6 +84,9 @@ process INDIVIDUAL_ANALYSIS {
     no_main_report = VersionUtils.versionLessThan(params.diann_version, '2.3') ? "--no-main-report" : ""
     // DIA-NN Enterprise license; falls back to a key next to the binary when no path is provided
     license_arg = diann_license ? "--license ${diann_license}" : ""
+    // DIA-NN Enterprise: Knowledge Base (--kb) boosts identifications (mainly human data).
+    // Must be on the actual per-file search, not just the preliminary calibration pass.
+    kb = params.enable_kb ? "--kb" : ""
 
     // Per-file scan ranges from SDRF (empty = no flag, DIA-NN auto-detects)
     min_pr_mz = meta['ms1minmz'] ? "--min-pr-mz ${meta['ms1minmz']}" : ""
@@ -110,6 +113,7 @@ process INDIVIDUAL_ANALYSIS {
             ${no_ifs_removal} \\
             ${no_main_report} \\
             ${license_arg} \\
+            ${kb} \\
             --relaxed-prot-inf \\
             --pg-level $params.pg_level \\
             ${min_pr_mz} \\

--- a/modules/local/diann/individual_analysis/main.nf
+++ b/modules/local/diann/individual_analysis/main.nf
@@ -55,15 +55,12 @@ process INDIVIDUAL_ANALYSIS {
             scan_window  = params.scan_window
         }
     } else {
+        // Not auto-calibrating: SDRF ppm tolerances if provided, otherwise the param
+        // defaults. Calibration values are intentionally NOT used here.
         if (meta['precursormasstoleranceunit']?.toLowerCase()?.endsWith('ppm') && meta['fragmentmasstoleranceunit']?.toLowerCase()?.endsWith('ppm')) {
             mass_acc_ms1 = meta["precursormasstolerance"]
             mass_acc_ms2 = meta["fragmentmasstolerance"]
             scan_window  = params.scan_window
-        }
-        else if (meta.mass_acc_ms2 != "0" && meta.mass_acc_ms2 != null) {
-            mass_acc_ms2 = meta.mass_acc_ms2
-            mass_acc_ms1 = meta.mass_acc_ms1
-            scan_window  = meta.scan_window
         }
         else {
             mass_acc_ms2 = params.mass_acc_ms2

--- a/modules/local/diann/preliminary_analysis/main.nf
+++ b/modules/local/diann/preliminary_analysis/main.nf
@@ -34,7 +34,9 @@ process PRELIMINARY_ANALYSIS {
     // Performance flags for preliminary analysis calibration step
     quick_mass_acc = params.quick_mass_acc ? "--quick-mass-acc" : ""
     performance_flags = params.performance_mode ? "--min-corr 2 --corr-diff 1 --time-corr-only" : ""
-    // DIA-NN Enterprise: Knowledge Base on the first-pass search (boosts IDs, mainly human data)
+    // DIA-NN Enterprise: Knowledge Base (--kb) on the mass-accuracy calibration pass
+    // (boosts IDs, mainly human data). Also applied to the search passes
+    // (ASSEMBLE_EMPIRICAL_LIBRARY, INDIVIDUAL_ANALYSIS) where identification happens.
     kb = params.enable_kb ? "--kb" : ""
     // DIA-NN Enterprise license; falls back to a key next to the binary when no path is provided
     license_arg = diann_license ? "--license ${diann_license}" : ""

--- a/nextflow.config
+++ b/nextflow.config
@@ -121,7 +121,7 @@ params {
     export_xic              = false
     quantums                = true  // use QuantUMS (DIA-NN's recommended quantification) for DIA-NN >= 1.9.2; false adds '--direct-quant' (legacy quant)
     quantums_train_runs     = null
-    quantums_sel_runs       = null
+    quantums_sel_runs       = 20    // '--quant-sel-runs N': auto-select N runs to optimise QuantUMS params; keeps QuantUMS fast on large cohorts (only applied when QuantUMS is active)
     quantums_params         = null
     use_quant               = true // add '--use-quant' to FINAL_QUANTIFICATION
     channel_run_norm        = false // add '--channel-run-norm' to FINAL_QUANTIFICATION

--- a/nextflow.config
+++ b/nextflow.config
@@ -119,7 +119,7 @@ params {
     normalize               = true
     report_decoys           = false
     export_xic              = false
-    quantums                = false
+    quantums                = true  // use QuantUMS (DIA-NN's recommended quantification) for DIA-NN >= 1.9.2; false adds '--direct-quant' (legacy quant)
     quantums_train_runs     = null
     quantums_sel_runs       = null
     quantums_params         = null

--- a/nextflow.config
+++ b/nextflow.config
@@ -118,7 +118,7 @@ params {
     mass_acc_ms1    = 10
 
     // DIA-NN: FINAL_QUANTIFICATION — summarization & output
-    pg_level                = 2
+    pg_level                = 2     // protein-group inference level (2 = gene-level). Correct for UniProt FASTAs with gene names; gene-less FASTAs (e.g. ProteoBench HYE) are unaffected (DIA-NN falls back), so kept at 2 by default.
     species_genes           = false
     normalize               = true
     report_decoys           = false

--- a/nextflow.config
+++ b/nextflow.config
@@ -110,8 +110,12 @@ params {
     empirical_assembly_ms_n      = 200
 
     // DIA-NN: INDIVIDUAL_ANALYSIS
-    mass_acc_ms2    = 15
-    mass_acc_ms1    = 15
+    // Fallback mass accuracy (ppm) used when neither auto-calibration (mass_acc_automatic)
+    // nor SDRF ppm tolerances provide a value. Priority:
+    //   mass_acc_automatic=true  -> calibration > SDRF ppm > these defaults
+    //   mass_acc_automatic=false -> SDRF ppm > these defaults
+    mass_acc_ms2    = 20
+    mass_acc_ms1    = 10
 
     // DIA-NN: FINAL_QUANTIFICATION — summarization & output
     pg_level                = 2

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -352,14 +352,14 @@
                     "description": "Set the MS2 mass accuracy (tolerance) to a specific value in ppm.",
                     "fa_icon": "fas fa-bullseye",
                     "help_text": "If specified, this overrides the automatic calibration. Corresponds to the --mass-acc parameter in DIA-NN.",
-                    "default": 15
+                    "default": 20
                 },
                 "mass_acc_ms1": {
                     "type": "number",
                     "description": "Set the MS1 mass accuracy (tolerance) to a specific value in ppm.",
                     "fa_icon": "fas fa-bullseye",
                     "help_text": "If specified, this overrides the automatic calibration. Corresponds to the --mass-acc-ms1 parameter in DIA-NN.",
-                    "default": 15
+                    "default": 10
                 },
                 "performance_mode": {
                     "type": "boolean",
@@ -426,8 +426,9 @@
                 },
                 "quantums": {
                     "type": "boolean",
-                    "description": "Use legacy DIA-NN quantification algorithms (DIA-NN parameter --direct-quant); if true, QuantUMS is enabled.",
+                    "description": "Use QuantUMS quantification for DIA-NN >= 1.9.2 (default). If false, adds --direct-quant for legacy quantification.",
                     "fa_icon": "far fa-check-square",
+                    "default": true,
                     "hidden": false
                 },
                 "quantums_train_runs": {
@@ -442,6 +443,7 @@
                     "description": "Number of automatically selected runs for QuantUMS training.",
                     "fa_icon": "fas fa-sliders-h",
                     "help_text": "Sets the DIA-NN parameter --quant-sel-runs. Format: [N]. QuantUMS will train its parameters on N automatically selected runs to speed up training in large experiments. N must be 6 or greater.",
+                    "default": 20,
                     "hidden": false
                 },
                 "quantums_params": {

--- a/workflows/dia.nf
+++ b/workflows/dia.nf
@@ -294,30 +294,44 @@ workflow DIA {
                     def ms2s = rows.collect { it[0] }.findAll { it != null }
                     def ms1s = rows.collect { it[1] }.findAll { it != null }
                     def sws  = rows.collect { it[2] }.findAll { it != null }
-                    def ms2 = ms2s ? ((ms2s.sum() as Double) / ms2s.size()).round(1) : params.mass_acc_ms2
-                    def ms1 = ms1s ? ((ms1s.sum() as Double) / ms1s.size()).round(1) : params.mass_acc_ms1
-                    def sw  = sws  ? Math.round((sws.sum() as Double) / sws.size())   : params.scan_window
-                    log.info "DIA-NN >= 2.5.0: optimised mass accuracy from PRELIMINARY logs " +
-                             "(averaged over ${ms1s.size()} run(s)): MS2=${ms2} ppm, MS1=${ms1} ppm, scan window=${sw}"
-                    return "${ms2},${ms1},${sw}"
+                    if (ms2s && ms1s) {
+                        def ms2 = ((ms2s.sum() as Double) / ms2s.size()).round(1)
+                        def ms1 = ((ms1s.sum() as Double) / ms1s.size()).round(1)
+                        def sw  = sws ? Math.round((sws.sum() as Double) / sws.size()) : params.scan_window
+                        log.info "DIA-NN >= 2.5.0: optimised mass accuracy from PRELIMINARY logs " +
+                                 "(averaged over ${ms1s.size()} run(s)): MS2=${ms2} ppm, MS1=${ms1} ppm, scan window=${sw}"
+                        return "${ms2},${ms1},${sw}"
+                    }
+                    // Calibration could not be parsed -> emit a 0,0,0 sentinel so
+                    // INDIVIDUAL_ANALYSIS falls back to the previous reliable value
+                    // (SDRF ppm tolerances if annotated, otherwise the param defaults).
+                    log.warn "DIA-NN >= 2.5.0: could not parse optimised mass accuracy from PRELIMINARY " +
+                             "logs; INDIVIDUAL_ANALYSIS will use SDRF ppm tolerances or mass_acc_ms1/ms2 defaults."
+                    return "0,0,0"
                 }
         } else {
             // DIA-NN < 2.5.0: the ASSEMBLE "Averaged recommended settings" line is reliable.
             ch_parsed_vals = ASSEMBLE_EMPIRICAL_LIBRARY.out.log
                 .map { log_file ->
-                    def ms1 = "${params.mass_acc_ms1}"
-                    def ms2 = "${params.mass_acc_ms2}"
-                    def sw = "${params.scan_window}"
                     def match = log_file.text.readLines().find { it.contains("Averaged recommended settings") }
                     if (match) {
+                        def ms1 = null
+                        def ms2 = null
+                        def sw  = null
                         def ms1_match = match =~ /MS1 accuracy\s*=\s*([0-9.]+)/
                         if (ms1_match.find()) ms1 = ms1_match.group(1)
                         def ms2_match = match =~ /(?:MS2|Mass) accuracy\s*=\s*([0-9.]+)/
                         if (ms2_match.find()) ms2 = ms2_match.group(1)
                         def sw_match = match =~ /Scan window\s*=\s*([0-9.]+)/
                         if (sw_match.find()) sw = sw_match.group(1)
+                        if (ms1 != null && ms2 != null) {
+                            return "${ms2},${ms1},${sw ?: params.scan_window}"
+                        }
                     }
-                    return "${ms2},${ms1},${sw}"
+                    // Calibration could not be parsed -> sentinel, fall back to SDRF/params downstream.
+                    log.warn "DIA-NN < 2.5.0: could not parse 'Averaged recommended settings' from the " +
+                             "ASSEMBLE log; INDIVIDUAL_ANALYSIS will use SDRF ppm tolerances or mass_acc_ms1/ms2 defaults."
+                    return "0,0,0"
                 }
         }
         indiv_fin_analysis_in = ch_file_preparation_results

--- a/workflows/dia.nf
+++ b/workflows/dia.nf
@@ -262,24 +262,64 @@ workflow DIA {
         )
         ch_software_versions = ch_software_versions
             .mix(ASSEMBLE_EMPIRICAL_LIBRARY.out.versions)
-        // Parse calibrated params from the assembly log on the head node
-        // Format changed in 2.5.0
-        ch_parsed_vals = ASSEMBLE_EMPIRICAL_LIBRARY.out.log
-            .map { log_file ->
-                def ms1 = "${params.mass_acc_ms1}"
-                def ms2 = "${params.mass_acc_ms2}"
-                def sw = "${params.scan_window}"
-                def match = log_file.text.readLines().find { it.contains("Averaged recommended settings") }
-                if (match) {
-                    def ms1_match = match =~ /MS1 accuracy\s*=\s*([0-9.]+)/
-                    if (ms1_match.find()) ms1 = ms1_match.group(1)
-                    def ms2_match = match =~ /(?:MS2|Mass) accuracy\s*=\s*([0-9.]+)/
-                    if (ms2_match.find()) ms2 = ms2_match.group(1)
-                    def sw_match = match =~ /Scan window\s*=\s*([0-9.]+)/
-                    if (sw_match.find()) sw = sw_match.group(1)
+        // Capture the optimised mass accuracy / scan window for the per-file search.
+        //
+        // DIA-NN >= 2.5.0 emits an UNRELIABLE "Averaged recommended settings" line in the
+        // ASSEMBLE_EMPIRICAL_LIBRARY log: that step combines --use-quant with
+        // --individual-mass-acc, which DIA-NN flags as "strongly not recommended" and then
+        // falls back to a default MS1 = 20 ppm (far too wide e.g. for Orbitrap Astral),
+        // decoupled from the genuine per-run optimisation. So for >= 2.5.0 we read the real
+        // optimised values from each PRELIMINARY log ("Recommended MS1 mass accuracy setting"
+        // = MS1, "Suggested mass accuracy" = MS2, "Scan window radius set to" = window) and
+        // average across runs. DIA-NN < 2.5.0 keeps the (correct, for that format) ASSEMBLE
+        // "Averaged recommended settings" line.
+        if (VersionUtils.versionAtLeast(params.diann_version, '2.5.0')) {
+            ch_parsed_vals = PRELIMINARY_ANALYSIS.out.log
+                .map { _meta, log_file ->
+                    Double ms1 = null
+                    Double ms2 = null
+                    Double sw  = null
+                    log_file.text.readLines().each { line ->
+                        def m1 = line =~ /Recommended MS1 mass accuracy setting:\s*([0-9.]+)/
+                        if (m1.find()) ms1 = m1.group(1) as Double
+                        def m2 = line =~ /Suggested mass accuracy:\s*([0-9.]+)/
+                        if (m2.find()) ms2 = m2.group(1) as Double
+                        def ws = line =~ /Scan window radius set to\s*([0-9.]+)/
+                        if (ws.find()) sw = ws.group(1) as Double
+                    }
+                    return [ ms2, ms1, sw ]
                 }
-                return "${ms2},${ms1},${sw}"
-            }
+                .collect()
+                .map { rows ->
+                    def ms2s = rows.collect { it[0] }.findAll { it != null }
+                    def ms1s = rows.collect { it[1] }.findAll { it != null }
+                    def sws  = rows.collect { it[2] }.findAll { it != null }
+                    def ms2 = ms2s ? ((ms2s.sum() as Double) / ms2s.size()).round(1) : params.mass_acc_ms2
+                    def ms1 = ms1s ? ((ms1s.sum() as Double) / ms1s.size()).round(1) : params.mass_acc_ms1
+                    def sw  = sws  ? Math.round((sws.sum() as Double) / sws.size())   : params.scan_window
+                    log.info "DIA-NN >= 2.5.0: optimised mass accuracy from PRELIMINARY logs " +
+                             "(averaged over ${ms1s.size()} run(s)): MS2=${ms2} ppm, MS1=${ms1} ppm, scan window=${sw}"
+                    return "${ms2},${ms1},${sw}"
+                }
+        } else {
+            // DIA-NN < 2.5.0: the ASSEMBLE "Averaged recommended settings" line is reliable.
+            ch_parsed_vals = ASSEMBLE_EMPIRICAL_LIBRARY.out.log
+                .map { log_file ->
+                    def ms1 = "${params.mass_acc_ms1}"
+                    def ms2 = "${params.mass_acc_ms2}"
+                    def sw = "${params.scan_window}"
+                    def match = log_file.text.readLines().find { it.contains("Averaged recommended settings") }
+                    if (match) {
+                        def ms1_match = match =~ /MS1 accuracy\s*=\s*([0-9.]+)/
+                        if (ms1_match.find()) ms1 = ms1_match.group(1)
+                        def ms2_match = match =~ /(?:MS2|Mass) accuracy\s*=\s*([0-9.]+)/
+                        if (ms2_match.find()) ms2 = ms2_match.group(1)
+                        def sw_match = match =~ /Scan window\s*=\s*([0-9.]+)/
+                        if (sw_match.find()) sw = sw_match.group(1)
+                    }
+                    return "${ms2},${ms1},${sw}"
+                }
+        }
         indiv_fin_analysis_in = ch_file_preparation_results
             .combine(ch_searchdb)
             .combine(ASSEMBLE_EMPIRICAL_LIBRARY.out.empirical_library)


### PR DESCRIPTION
## Summary

Bug fixes for the DIA-NN modules, found while benchmarking quantmsdiann against ProteoBench (DIA-NN 1.8.1 / 2.5.1 / 2.5.1-enterprise) and reviewed with DIA-NN's author (V. Demichev). These address cross-version comparison confounders and a few configuration issues on the Enterprise / 2.5.x path.

## Changes

1. **`--kb` (Enterprise Knowledge Base) on the search passes** — it was only wired into `PRELIMINARY_ANALYSIS` (quick mass-acc calibration), not where identification happens. Added to `ASSEMBLE_EMPIRICAL_LIBRARY` (first-pass search) and `INDIVIDUAL_ANALYSIS` (per-file search), gated by `params.enable_kb`.

2. **QuantUMS on by default for DIA-NN ≥ 1.9.2** — `params.quantums` defaulted to `false`, forcing `--direct-quant` and disabling QuantUMS (DIA-NN's recommended quantification). Flipped to `true`; the `--direct-quant` opt-out stays version-gated, so 1.8.1 is unaffected.

3. **`--quant-sel-runs 20` default + version-gated QuantUMS tuning flags** — QuantUMS over thousands of runs is slow; auto-select 20 runs to optimise its params. `--quant-sel-runs/--quant-train-runs/--quant-params` now only apply when QuantUMS is active (`params.quantums && DIA-NN ≥ 1.9.2`), so they're never passed to versions that don't support them.

4. **Mass-accuracy resolution (the main confounder)** — the per-file search mass accuracy was read from the `ASSEMBLE_EMPIRICAL_LIBRARY` "Averaged recommended settings" log line. On DIA-NN ≥ 2.5.0 that step combines `--use-quant` with `--individual-mass-acc`, which DIA-NN flags as "strongly not recommended" and then prints a default **MS1 = 20 ppm** (vs the genuine ~3 ppm), so 2.5.x searched at MS1 = 20 ppm while 1.8.1 used 3 ppm. Now:
   - DIA-NN ≥ 2.5.0: read the optimised values from each **PRELIMINARY** log (`Recommended MS1 mass accuracy setting` / `Suggested mass accuracy` / `Scan window radius`) and average across runs.
   - DIA-NN < 2.5.0: keep the (correct for that format) ASSEMBLE averaged line.
   - Resolution priority — `mass_acc_automatic=true`: calibration > SDRF ppm > defaults; `mass_acc_automatic=false`: SDRF ppm > defaults (calibration excluded). Defaults updated 15/15 → **20/10 ppm**.
   - When calibration can't be parsed, a `0,0,0` sentinel makes `INDIVIDUAL_ANALYSIS` fall back to the previous reliable value (SDRF if annotated, else params) instead of silently using defaults.

5. **`--no-prot-inf` in `FINAL_QUANTIFICATION`** — protein groups are already inferred when the empirical library is built; reuse that inference in the final quant instead of re-inferring with `--relaxed-prot-inf`, so the final report matches the library.

6. **Docs** — record the decision to keep `pg_level = 2`.

## Validation

- `nextflow lint` is clean (only the expected `lib/` class false positives).
- **Needs a `-profile test` run** to validate the new preliminary-log parsing / averaging / sentinel path at runtime.

## Not in this PR
- Stray `--mass-acc 20 / --mass-acc-ms1 10` written into `diann_config.cfg` by `quantms-utils` (`dianncfg`) — inert here (not extracted into `mod_flags`); to be fixed in `quantms-utils`.
- Empty-signatures warning on every 2.5.x empirical library (all precursors) — open question for DIA-NN upstream.

Reported/reviewed by V. Demichev.
