### PR TITLE
chore: bump sdrf-pipelines 0.1.4 -> 0.1.5 (fixes multi-residue mod site truncation)

### DIFF
--- a/modules/local/sdrf_parsing/main.nf
+++ b/modules/local/sdrf_parsing/main.nf
@@ -3,8 +3,8 @@ process SDRF_PARSING {
     label 'process_tiny'
 
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/sdrf-pipelines:0.1.4--pyhdfd78af_0' :
-        'biocontainers/sdrf-pipelines:0.1.4--pyhdfd78af_0' }"
+        'https://depot.galaxyproject.org/singularity/sdrf-pipelines:0.1.5--pyhdfd78af_0' :
+        'biocontainers/sdrf-pipelines:0.1.5--pyhdfd78af_0' }"
 
     input:
     path sdrf


### PR DESCRIPTION
## Summary

Bump **sdrf-pipelines `0.1.4` → `0.1.5`** in `SDRF_PARSING` (the step that produces `diann_config.cfg` via `parse_sdrf convert-diann`).

## Why

`0.1.4`'s `parse_sdrf convert-diann` emits multi-residue modification sites **comma-separated**, e.g. for an SDRF `NT=Phospho;TA=S,T,Y`:

```
--var-mod Phospho,79.966331,S,T,Y
```

DIA-NN keeps only the **first** residue of a comma-separated site list (the rest land in the 4th "label" field), so it logs `Modification Phospho … at S will be considered as variable` and **silently drops pT and pY**. This affects any modification on multiple residues (e.g. `Oxidation,…,M,P` → M only).

Confirmed on our **PXD049692** phospho-diaPASEF reanalysis (DIA-NN 2.5.1): the run captured **Serine phosphosites only**.

`0.1.5` fixes the converter to concatenate multi-residue sites and merge same-(name, mass) entries:

```
Phospho;TA=S,T,Y  → Phospho,79.966331,STY
Oxidation;TA=M,P  → Oxidation,15.994915,MP
```

## Notes

- Container tag verified published: `biocontainers/sdrf-pipelines:0.1.5--pyhdfd78af_0` (bioconda `latest_version: 0.1.5`).
- Two-line change; the fix itself lives in sdrf-pipelines (`converters/diann/modifications.py`, released in 0.1.5).
- Datasets with multi-residue mods (phospho, etc.) should be re-run after this lands to capture all target residues.
