### PR TITLE
fix(diann): use toList() not collect() for per-run mass-acc triples (runtime crash on DIA-NN >= 2.5.0)

### DIFF
--- a/workflows/dia.nf
+++ b/workflows/dia.nf
@@ -289,7 +289,7 @@ workflow DIA {
                     }
                     return [ ms2, ms1, sw ]
                 }
-                .collect()
+                .toList()  // toList (not collect): keep per-run [ms2,ms1,sw] triples; collect() would flatten them
                 .map { rows ->
                     def ms2s = rows.collect { it[0] }.findAll { it != null }
                     def ms1s = rows.collect { it[1] }.findAll { it != null }


### PR DESCRIPTION
## Summary

Hotfix for a runtime crash in the DIA-NN >= 2.5.0 mass-accuracy branch added in #104.

`ch_parsed_vals` maps each PRELIMINARY log to a `[ms2, ms1, sw]` triple, then `.collect().map { rows -> rows.collect { it[0] } ... }`. **Nextflow's `.collect()` flattens nested lists**, so `rows` was a flat list of Doubles and `it[0]` threw:

```
ERROR ~ Unknown method invocation `getAt` on Double type -- dia.nf line 294
```

Fix: `.collect()` -> `.toList()` (collects the per-run triples without flattening).

## How it slipped through
CI only runs DIA-NN <= 2.2.0, which takes the `else` (assemble-log) branch; the new >= 2.5.0 branch was first executed by the **Module 7 / DIA-NN 2.5.1** cluster validation, which caught it after the 6 PRELIMINARY tasks. The preliminary masses themselves were captured correctly (MS1 ~2.5 ppm); only the aggregation crashed.