### PR TITLE
fix(qpx): filter at precursor_qvalue, and re-vendor qpx/diann at 1.1.3

### DIFF
--- a/modules/bigbio/qpx/diann/main.nf
+++ b/modules/bigbio/qpx/diann/main.nf
@@ -31,7 +31,12 @@ process QPX_DIANN {
     def pg_arg  = pg_matrix ? "--pg-matrix-path ${pg_matrix}" : ''
     def log_arg = diann_log ? "--diann-log ${diann_log}" : ''
     def acc_arg = project_accession ? "--project-accession ${project_accession}" : ''
-    def qvalue  = params.matrix_qvalue ?: 0.05
+    // Precursor-level cutoff for the features qpx writes. This must follow the
+    // pipeline's precursor q-value (--qvalue), NOT matrix_qvalue: the latter
+    // governs DIA-NN's output matrices, and using it here silently re-filtered
+    // the report to 1% while the run itself was analysed at the DIA-NN >= 2.5
+    // default of 5%. Unset precursor_qvalue keeps that 5% default.
+    def qvalue  = params.precursor_qvalue ?: 0.05
     """
     set -o pipefail
     qpxc convert diann \\


### PR DESCRIPTION
Filters the qpx conversion at the precursor q-value, and re-vendors the module now that the upstream fix is merged.

## The fix

`QPX_DIANN` passed the feature cutoff from `params.matrix_qvalue`. That is DIA-NN's **output-matrix** threshold — a different quantity. The effect was that the qpx artifact was re-filtered to 1% while the run itself was analysed at DIA-NN's 5% precursor default, so the published parquet silently disagreed with the rest of the run.

The fix landed upstream in bigbio/nf-modules#49, so this branch no longer hand-edits the vendored file — it re-vendors it properly.

## Re-vendor

All five files are byte-identical to `nf-modules@8bb3d46` and `modules.json` `git_sha` is updated to match, which clears the nf-core lint `check_local_copy` failure this branch had. It also brings in `tests/`, which the vendored copy was missing while the other `bigbio` modules here carry theirs.

qpx moves **1.1.1 -> 1.1.3** (container and conda pin together, so the docker and conda profiles cannot run different code). 1.1.3 adds the DIA-NN `mass_error_ppm` derivation, the OpenMS confidence fields, atomic parquet writes, and the sharded-collection/partitioned-integrity fixes.

## One gap this does not close

Tracing the call site turned up a related inconsistency that is **out of scope here** and needs its own change:

`precursor_qvalue` defaults to `null`, and the pipeline resolves it version-aware via `VersionUtils.resolvePrecursorQvalue` — `0.01` for DIA-NN < 2.5, `0.05` for >= 2.5. Both `final_quantification` and `diann_msstats` call that resolver. The vendored module cannot: it is generic and has no access to `lib/`, so it falls back to `params.precursor_qvalue ?: 0.05`.

So on the **default settings with DIA-NN < 2.5** (1.8.1, 2.2.0), the run is quantified and MSstats-filtered at 1% while qpx converts at 5% — the artifact is looser than the run it documents. This PR does not make that worse (it is strictly better than the previous 1% matrix cutoff), but it does not fix it either.

I verified the mechanics: `--qvalue-threshold` is last-wins in the CLI, so `ext.args` in `conf/modules/shared.config` can supply the resolved value without touching the shared module. Happy to do that as a follow-up.
