### PR TITLE
chore(modules): re-vendor pmultiqc 0.0.48 from nf-modules

### DIFF
--- a/modules.json
+++ b/modules.json
@@ -14,7 +14,14 @@
                     },
                     "qpx/diann": {
                         "branch": "main",
-                        "git_sha": "8bb3d461d93e2b008ce4992d4a2af2774a9943c9",
+                        "git_sha": "7cd54b39383fed0257b916e1060608b7ef322023",
+                        "installed_by": [
+                            "modules"
+                        ]
+                    },
+                    "pmultiqc": {
+                        "branch": "main",
+                        "git_sha": "7cd54b39383fed0257b916e1060608b7ef322023",
                         "installed_by": [
                             "modules"
                         ]

--- a/modules/bigbio/pmultiqc/environment.yml
+++ b/modules/bigbio/pmultiqc/environment.yml
@@ -4,4 +4,4 @@ channels:
   - bioconda
   - defaults
 dependencies:
-  - bioconda::pmultiqc=0.0.47
+  - bioconda::pmultiqc=0.0.48

--- a/modules/bigbio/pmultiqc/main.nf
+++ b/modules/bigbio/pmultiqc/main.nf
@@ -5,8 +5,8 @@ process PMULTIQC {
     // pmultiqc is published to bioconda/biocontainers on release; a single image
     // serves Docker (native) and Singularity (via the galaxy depot mirror).
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/pmultiqc:0.0.47--pyhdfd78af_0' :
-        'biocontainers/pmultiqc:0.0.47--pyhdfd78af_0' }"
+        'https://depot.galaxyproject.org/singularity/pmultiqc:0.0.48--pyhdfd78af_0' :
+        'biocontainers/pmultiqc:0.0.48--pyhdfd78af_0' }"
 
     input:
     // Everything the report needs, staged flat under `results/`. Consumers collect
@@ -45,7 +45,7 @@ process PMULTIQC {
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":
-        pmultiqc: \$(multiqc --pmultiqc_version | sed -e "s/pmultiqc, version //g" 2>/dev/null || echo "0.0.47")
+        pmultiqc: \$(multiqc --pmultiqc_version | sed -e "s/pmultiqc, version //g" 2>/dev/null || echo "0.0.48")
     END_VERSIONS
     """
 }


### PR DESCRIPTION
Re-vendors `modules/bigbio/pmultiqc` and `modules/bigbio/qpx/diann` from bigbio/nf-modules main (`0e150a7`, after bigbio/nf-modules#50), and bumps both `git_sha` entries in `modules.json` to match.

| module | from | to |
|---|---|---|
| pmultiqc | 0.0.47 | 0.0.48 |
| qpx/diann | 1.1.2 | 1.1.3 |

**pmultiqc 0.0.48** is the big-DIA memory release. The summary step for PXD030304 previously OOM'd at 234 GB; it now completes at a **68.0 GiB peak in 15 min**, with the module present and all sections rendered.

### Overlap with #120 — please read

The vendored `qpx/diann/main.nf` now carries the `precursor_qvalue` fix **upstream**, because it went into nf-modules. That is byte-for-byte the change #120 makes downstream, so **#120 is now redundant** and should be closed, or merged before this and the conflict resolved in favour of the vendored copy. Either is fine, but they should not both land as independent edits to a vendored file — the next re-vendor would silently revert whichever one only exists downstream.

### Verified before pinning

Every artifact was confirmed to resolve rather than assumed: galaxy-depot singularity `pmultiqc:0.0.48--pyhdfd78af_0`, quay biocontainers 0.0.48, `bioconda::pmultiqc=0.0.48`, and `ghcr.io/bigbio/qpx:1.1.3`.

### Also included

`modules/bigbio/qpx/diann/tests/` — upstream has these and this checkout did not, so the vendored copy was incomplete.

Related: bigbio/nf-modules#51 makes the openmsconsensus bioconda comment version-agnostic (it still named 1.1.2 next to a 1.1.3 pin).