### PR TITLE
summary: stop staging msstats_in.csv into the pmultiqc step

### DIFF
--- a/workflows/quantmsdiann.nf
+++ b/workflows/quantmsdiann.nf
@@ -94,7 +94,6 @@ workflow QUANTMSDIANN {
     //
     ch_pipeline_results = channel.empty()
     ch_ids_pmultiqc = channel.empty()
-    ch_msstats_in = channel.empty()
     ch_consensus_pmultiqc = channel.empty()
 
     DIA(
@@ -103,7 +102,6 @@ workflow QUANTMSDIANN {
         CREATE_INPUT_CHANNEL.out.ch_diann_cfg,
     )
     ch_pipeline_results = ch_pipeline_results.mix(DIA.out.diann_report)
-    ch_msstats_in = ch_msstats_in.mix(DIA.out.msstats_in)
     ch_versions = ch_versions.mix(DIA.out.versions)
 
     // Other subworkflow will return null when performing another subworkflow due to unknown reason.
@@ -140,7 +138,22 @@ workflow QUANTMSDIANN {
         .mix(ch_multiqc_files.collect())
         .mix(ch_ids_pmultiqc.collect().ifEmpty([]))
         .mix(ch_consensus_pmultiqc.collect().ifEmpty([]))
-        .mix(ch_msstats_in.ifEmpty([]))
+        // msstats_in.csv is deliberately NOT staged here. When pmultiqc sees it,
+        // parse_msstats_input builds the peptide/protein quantification tables
+        // from it -- on PXD030304 that is a 20.6 GiB, 231 M-row CSV that
+        // pd.read_csv turns into ~93 GB, and it is the summary step's single
+        // largest memory cost (bigbio/pmultiqc#717).
+        //
+        // Withholding it loses nothing: pmultiqc draws the same two tables from
+        // the DIA-NN report instead, which is already in memory --
+        // `if not msstats_input_valid: draw_diann_quant_table(...)` in
+        // _draw_diann_plots. On DIA the report-derived table is the better of
+        // the two anyway, since without an mzTab the MSstats path sets
+        // BestSearchScore to NaN.
+        //
+        // The file itself is unaffected: DIANN_MSSTATS publishes it to
+        // ${params.outdir}/quant_tables via its own publishDir.
+        // See bigbio/pmultiqc#732.
         .collect()
 
     SUMMARY_PIPELINE(multiqc_inputs)


### PR DESCRIPTION
Removes the summary step's largest memory cost, with no change to the report's content.

### What

`multiqc_inputs` no longer mixes in `ch_msstats_in`.

### Why this is free

When pmultiqc sees an MSstats input, `parse_msstats_input` builds the peptide/protein quantification tables from it. On PXD030304 that CSV is **20.6 GiB / 231 M rows**, and `pd.read_csv` turns it into **~93 GB** of Python strings (bigbio/pmultiqc#717).

pmultiqc already has the cheap path wired, in `_draw_diann_plots`:

```python
# Draw quantification table if not using msstats
if not msstats_input_valid:
    draw_diann_quant_table(sub_sections["quantification"], report_data, sample_df, file_df)
```

The two are mutually exclusive by design, not additive. Withholding the CSV switches pmultiqc to the DIA-NN report, which is already in memory, for **the same two tables**. On DIA the report-derived version is arguably better: with no mzTab the MSstats path sets `BestSearchScore` to NaN and logs `No mzTab found`.

### What is not affected

`msstats_in.csv` is still produced and still published — `DIANN_MSSTATS` has its own `publishDir` to `${params.outdir}/quant_tables`. Only the summary step stops receiving it. `ch_msstats_in` had no other consumer so it is removed; the DIA subworkflow still emits `msstats_in`.

### Verified

`nextflow lint` (25.10.4) reports the identical 23 pre-existing errors in 9 other files before and after; `workflows/quantmsdiann.nf` itself has none.

### Relation to the other PRs

- #122 is now just the OOM retry (`memory = { 72.GB * task.attempt }` + retry on 137/140). This PR is what actually removes the cost; #122 is the safety net.
- bigbio/pmultiqc#732 asks upstream to prefer the report-derived table on DIA by default, which would make this unnecessary. Not blocking — the fallback already exists, which is why this works today.

### Not measured

What the report-derived tables cost at ~5,800 runs. The 68 GiB peak in bigbio/pmultiqc#717 was measured with `--disable-table`, so both table paths were off. This PR turns the cheap one back on, so the peak may land somewhat above that.